### PR TITLE
New attributes for recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /docs/build/
 Manifest.toml
 /docs/Manifest.toml
+/docs/src/generated/

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 AbstractPlotting = "537997a7-5e4e-5d89-9595-2241ea00577e"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NetworkLayout = "46757867-2c16-5918-afeb-47bfcb05e46a"
@@ -16,8 +17,8 @@ NetworkLayout = "0.3"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "CairoMakie"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 
 [targets]
-test = ["Test"]
+test = ["Test", "GLMakie"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 
 [targets]
-test = ["Test", "GLMakie"]
+test = ["Test", "CairoMakie"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,5 @@
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
+LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
+Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AbstractPlotting = "537997a7-5e4e-5d89-9595-2241ea00577e"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"

--- a/docs/examples/interactions.jl
+++ b/docs/examples/interactions.jl
@@ -1,0 +1,145 @@
+#=
+# Add interactions to your graph plot
+
+In this example you will see, how to register interactions with your graph plot.
+We star with a simple wheel graph again. This time we use arrays for some attributes
+because we want to change them later in the interactions for individual nodes/edges.
+=#
+using CairoMakie
+CairoMakie.activate!(type="png") # hide
+AbstractPlotting.inline!(true) # hide
+using GraphMakie
+using LightGraphs
+using AbstractPlotting.Colors
+
+import Random; Random.seed!(2) # hide
+g = wheel_digraph(10)
+f, ax, p = graphplot(g,
+                     edge_width = [3.0 for i in 1:ne(g)],
+                     edge_color = [colorant"gray" for i in 1:ne(g)],
+                     node_size = [20 for i in 1:nv(g)],
+                     node_color = [colorant"red" for i in 1:nv(g)])
+hidedecorations!(ax); hidespines!(ax)
+ax.aspect = DataAspect()
+f # hide
+
+# Later on we want to enable drag interactions, therefore we disable the default
+# `:rectanglezoom` interaction
+deregister_interaction!(ax, :rectanglezoom)
+nothing #hide
+
+# ## Hover interactions
+# At first, let's add some hover interaction for our nodes using the [`NodeHoverHandler`](@ref)
+# constructor. We need to define a action function with the signature `fun(state, idx, event, axis)`.
+# We use the action to make the nodes bigger on hover events.
+function node_hover_action(state, idx, event, axis)
+    @info idx #hide
+    p.node_size[][idx] = state ? 40 : 20
+    p.node_size[] = p.node_size[] # trigger observable
+end
+nhover = NodeHoverHandler(node_hover_action)
+register_interaction!(ax, :nhover, nhover)
+
+function set_cursor!(p) #hide
+    direction = Point2f0(-0.1, 0.2) #hide
+    arrows!([p-direction], [direction], linewidth=5, arrowsize=30, lengthscale=0.8) #hide
+end #hide
+nodepos = copy(p[:node_positions][]) #hide
+set_cursor!(nodepos[5] + Point2f0(0.05, 0)) #hide
+p.node_size[][5] = 40; p.node_size[] = p.node_size[] #hide
+f #hide
+
+# Please run the script locally with `GLMakie.jl` if you want to play with the Graph 🙂
+# The edge hover interaction is quite similar:
+
+pop!(ax.scene.plots) #hide
+p.node_size[][5] = 20; p.node_size[] = p.node_size[] #hide
+function edge_hover_action(state, idx, event, axis)
+    @info idx #hide
+    p.edge_width[][idx]= state ? 6.0 : 3.0
+    p.edge_width[] = p.edge_width[] # trigger observable
+end
+ehover = EdgeHoverHandler(edge_hover_action)
+register_interaction!(ax, :ehover, ehover)
+
+set_cursor!((nodepos[4]+nodepos[1])/2) #hide
+p.edge_width[][3] = 6.0; p.edge_width[] = p.edge_width[] #hide
+f #hide
+
+# ## Click interactions
+# In a similar fashion we might change the color of nodes and lines by click.
+function node_click_action(idx, args...)
+    p.node_color[][idx] = rand(RGB)
+    p.node_color[] = p.node_color[]
+end
+nclick = NodeClickHandler(node_click_action)
+register_interaction!(ax, :nclick, nclick)
+
+function edge_click_action(idx, args...)
+    p.edge_color[][idx] = rand(RGB)
+    p.edge_color[] = p.edge_color[]
+end
+eclick = EdgeClickHandler(edge_click_action)
+register_interaction!(ax, :eclick, eclick)
+
+p.edge_color[][3] = colorant"blue"; p.edge_color[] = p.edge_color[] #hide
+p.node_color[][7] = colorant"yellow" #hide
+p.node_color[][2] = colorant"brown" #hide
+p.node_color[][9] = colorant"pink" #hide
+p.node_color[][6] = colorant"green" #hide
+p.node_color[] = p.node_color[] #hide
+f #hide
+
+# ## Drag interactions
+pop!(ax.scene.plots) #hide
+p.edge_width[][3] = 3.0; p.edge_width[] = p.edge_width[] #hide
+function node_drag_action(state, idx, event, axis)
+    p[:node_positions][][idx] = event.data
+    p[:node_positions][] = p[:node_positions][]
+end
+ndrag = NodeDragHandler(node_drag_action)
+register_interaction!(ax, :ndrag, ndrag)
+
+p[:node_positions][][1] = nodepos[1] + Point2f0(1.0,0.5) #hide
+p[:node_positions][] = p[:node_positions][] #hide
+set_cursor!(p[:node_positions][][1] + Point2f0(0.05, 0)) #hide
+p.node_size[][1] = 40; p.node_size[] = p.node_size[] #hide
+f # hide
+
+# The last example is not as straight forward. By dragging an edge we want to
+# change the positions of both attached nodes. Therefore we need some more state
+# inside the action. We can achieve this with a callable struct.
+pop!(ax.scene.plots) #hide
+p.node_size[][1] = 20; p.node_size[] = p.node_size[] #hide
+mutable struct EdgeDragAction
+    init::Union{Nothing, Point2f0} # save click position
+    src::Union{Nothing, Point2f0}  # save src vertex position
+    dst::Union{Nothing, Point2f0}  # save dst vertex position
+    EdgeDragAction() = new(nothing, nothing, nothing)
+end
+function (action::EdgeDragAction)(state, idx, event, axis)
+    edge = collect(edges(g))[idx]
+    if state == true
+        if action.src===action.dst===action.init===nothing
+            action.init = event.data
+            action.src = p[:node_positions][][edge.src]
+            action.dst = p[:node_positions][][edge.dst]
+        end
+        offset = event.data - action.init
+        p[:node_positions][][edge.src] = action.src + offset
+        p[:node_positions][][edge.dst] = action.dst + offset
+        p[:node_positions][] = p[:node_positions][] # trigger change
+    elseif state == false
+        action.src = action.dst = action.init =  nothing
+    end
+end
+edrag = EdgeDragHandler(EdgeDragAction())
+register_interaction!(ax, :edrag, edrag)
+
+p[:node_positions][][3] = nodepos[3] + Point2f0(0.9,1.0) #hide
+p[:node_positions][][4] = nodepos[4] + Point2f0(0.9,1.0) #hide
+p[:node_positions][] = p[:node_positions][] #hide
+pm = (p[:node_positions][][3] + p[:node_positions][][4])/2
+set_cursor!(pm) #hide
+p.edge_width[][11] = 6.0; p.edge_width[] = p.edge_width[] #hide
+f # hide

--- a/docs/examples/interactions.jl
+++ b/docs/examples/interactions.jl
@@ -7,6 +7,7 @@ because we want to change them later in the interactions for individual nodes/ed
 =#
 using CairoMakie
 CairoMakie.activate!(type="png") # hide
+set_theme!(resolution=(800, 400)) #hide
 AbstractPlotting.inline!(true) # hide
 using GraphMakie
 using LightGraphs
@@ -15,9 +16,9 @@ using AbstractPlotting.Colors
 import Random; Random.seed!(2) # hide
 g = wheel_digraph(10)
 f, ax, p = graphplot(g,
-                     edge_width = [3.0 for i in 1:ne(g)],
+                     edge_width = [2.0 for i in 1:ne(g)],
                      edge_color = [colorant"gray" for i in 1:ne(g)],
-                     node_size = [20 for i in 1:nv(g)],
+                     node_size = [10 for i in 1:nv(g)],
                      node_color = [colorant"red" for i in 1:nv(g)])
 hidedecorations!(ax); hidespines!(ax)
 ax.aspect = DataAspect()
@@ -34,7 +35,7 @@ nothing #hide
 # We use the action to make the nodes bigger on hover events.
 function node_hover_action(state, idx, event, axis)
     @info idx #hide
-    p.node_size[][idx] = state ? 40 : 20
+    p.node_size[][idx] = state ? 20 : 10
     p.node_size[] = p.node_size[] # trigger observable
 end
 nhover = NodeHoverHandler(node_hover_action)
@@ -42,28 +43,28 @@ register_interaction!(ax, :nhover, nhover)
 
 function set_cursor!(p) #hide
     direction = Point2f0(-0.1, 0.2) #hide
-    arrows!([p-direction], [direction], linewidth=5, arrowsize=30, lengthscale=0.8) #hide
+    arrows!([p-direction], [direction], linewidth=3, arrowsize=20, lengthscale=0.8) #hide
 end #hide
 nodepos = copy(p[:node_positions][]) #hide
 set_cursor!(nodepos[5] + Point2f0(0.05, 0)) #hide
-p.node_size[][5] = 40; p.node_size[] = p.node_size[] #hide
+p.node_size[][5] = 20; p.node_size[] = p.node_size[] #hide
 f #hide
 
 # Please run the script locally with `GLMakie.jl` if you want to play with the Graph 🙂
 # The edge hover interaction is quite similar:
 
 pop!(ax.scene.plots) #hide
-p.node_size[][5] = 20; p.node_size[] = p.node_size[] #hide
+p.node_size[][5] = 10; p.node_size[] = p.node_size[] #hide
 function edge_hover_action(state, idx, event, axis)
     @info idx #hide
-    p.edge_width[][idx]= state ? 6.0 : 3.0
+    p.edge_width[][idx]= state ? 5.0 : 2.0
     p.edge_width[] = p.edge_width[] # trigger observable
 end
 ehover = EdgeHoverHandler(edge_hover_action)
 register_interaction!(ax, :ehover, ehover)
 
 set_cursor!((nodepos[4]+nodepos[1])/2) #hide
-p.edge_width[][3] = 6.0; p.edge_width[] = p.edge_width[] #hide
+p.edge_width[][3] = 5.0; p.edge_width[] = p.edge_width[] #hide
 f #hide
 
 # ## Click interactions
@@ -92,7 +93,7 @@ f #hide
 
 # ## Drag interactions
 pop!(ax.scene.plots) #hide
-p.edge_width[][3] = 3.0; p.edge_width[] = p.edge_width[] #hide
+p.edge_width[][3] = 2.0; p.edge_width[] = p.edge_width[] #hide
 function node_drag_action(state, idx, event, axis)
     p[:node_positions][][idx] = event.data
     p[:node_positions][] = p[:node_positions][]
@@ -103,14 +104,14 @@ register_interaction!(ax, :ndrag, ndrag)
 p[:node_positions][][1] = nodepos[1] + Point2f0(1.0,0.5) #hide
 p[:node_positions][] = p[:node_positions][] #hide
 set_cursor!(p[:node_positions][][1] + Point2f0(0.05, 0)) #hide
-p.node_size[][1] = 40; p.node_size[] = p.node_size[] #hide
+p.node_size[][1] = 20; p.node_size[] = p.node_size[] #hide
 f # hide
 
 # The last example is not as straight forward. By dragging an edge we want to
 # change the positions of both attached nodes. Therefore we need some more state
 # inside the action. We can achieve this with a callable struct.
 pop!(ax.scene.plots) #hide
-p.node_size[][1] = 20; p.node_size[] = p.node_size[] #hide
+p.node_size[][1] = 10; p.node_size[] = p.node_size[] #hide
 mutable struct EdgeDragAction
     init::Union{Nothing, Point2f0} # save click position
     src::Union{Nothing, Point2f0}  # save src vertex position
@@ -141,5 +142,5 @@ p[:node_positions][][4] = nodepos[4] + Point2f0(0.9,1.0) #hide
 p[:node_positions][] = p[:node_positions][] #hide
 pm = (p[:node_positions][][3] + p[:node_positions][][4])/2
 set_cursor!(pm) #hide
-p.edge_width[][11] = 6.0; p.edge_width[] = p.edge_width[] #hide
+p.edge_width[][11] = 5.0; p.edge_width[] = p.edge_width[] #hide
 f # hide

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -5,6 +5,7 @@ is as simple as
 =#
 using CairoMakie
 CairoMakie.activate!(type="png") # hide
+set_theme!(resolution=(800, 400)) #hide
 AbstractPlotting.inline!(true) # hide
 using GraphMakie
 using LightGraphs
@@ -28,7 +29,7 @@ layout attribute can be any function which takes the adjacency matrix of the
 graph an returns a list of `(x,y)` tuples or `Point2f0` objects.
 
 Besides that there are some common attributes which are forwarded to the
-underlying plot commands. See [`graphplot(graph)`].
+underlying plot commands. See [`graphplot`](@ref).
 =#
 using GraphMakie.NetworkLayout
 

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -1,5 +1,6 @@
 #=
 # Plotting Graphs with `GraphMakie.jl`
+## The `graphplot` Command
 Plotting your first `AbstractGraph` from [`LightGraphs.jl`](https://juliagraphs.org/LightGraphs.jl/latest/)
 is as simple as
 =#
@@ -65,7 +66,7 @@ p.edge_color = p.edge_color[] # trigger observable
 f #hide
 
 #=
-## Nodelabels
+## Adding Node Labels
 =#
 Random.seed!(2)
 g = wheel_graph(10)
@@ -80,10 +81,69 @@ f, ax, p = graphplot(g,
 hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
 f # hide
 
-# This is not to nice, lets change the offsets based on the node_positions
+# This is not very nice, lets change the offsets based on the `node_positions`
 
-offsets = 0.10 * (p[:node_positions][] .- p[:node_positions][][1])
+offsets = 0.15 * (p[:node_positions][] .- p[:node_positions][][1])
 offsets[1] = Point2f0(0, 0.3)
 p.nlabels_offset[] = offsets
 autolimits!(ax)
 f # hide
+
+# ## Adding Edge Labels
+Random.seed!(42)
+g = barabasi_albert(6, 2)
+
+labels =  repr.(1:ne(g))
+
+f, ax, p = graphplot(g, elabels=labels,
+                     elabels_color=[:black for i in 1:ne(g)],
+                     edge_color=[:black for i in 1:ne(g)])
+hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
+f # hide
+
+#=
+The position of the edge labels is determined by several plot arguments.
+Each label is placed in the middle of the edge and rotated to match the edge rotation.
+
+Note: Since the `text` is displayed in the `screen` system, this rotations only really works
+for `DataAspect()`! See [the Makie docs](https://makie.juliaplots.org/stable/plotting_functions/text.html).
+
+The rotaion for each label can be overwritten with the `elabels_rotation` argument.
+=#
+p.elabels_rotation[] = Vector{Union{Nothing, Float64}}(nothing, ne(g))
+p.elabels_rotation[][5] = 0.0 # set absolute rotation angle for label 5
+p.elabels_rotation[] = p.elabels_rotation[]
+nothing #hide
+
+#=
+The position of each label can be modified using different arguments.
+  - `elabels_opposite` is a vector if edge indices which tells the plot to display labels on the oppisite site.
+  - `elabels_offset` will be added to the middle of the edge in axis coordinates
+  - `elabels_distance` increses/decreases the normal distance to the edge
+  - `elabels_shift` shifts the label along the edge
+  - `elabels_align` tells the `text` plot where to place the text in relation to the position
+=#
+p.elabels_opposite[] = [4,7]
+
+p.elabels_offset[] = [Point2f0(0.0, 0.0) for i in 1:ne(g)]
+p.elabels_offset[][5] = Point2f0(-0.4,0)
+p.elabels_offset[] = p.elabels_offset[]
+
+p.elabels_shift[] = zeros(ne(g))
+p.elabels_shift[][4] = -.5
+p.elabels_shift[][3] = +.2
+p.elabels_shift[] = p.elabels_shift[]
+
+p.elabels_distance[] = zeros(ne(g))
+p.elabels_distance[][8] = -.3
+p.elabels_distance[] = p.elabels_distance[]
+
+f # hide
+
+# Is it a bird?
+p.edge_width[] = 3.0
+p.elabels_color[] = [:green, :red, :green, :green, :red, :goldenrod1, :green, :goldenrod1]
+p.edge_color[] = [:green, :black, :green, :green, :black, :goldenrod1, :green, :goldenrod1]
+p.elabels[] =["left", "There\n should\n be an add-\n itional node\n for the wings!", "right", "leg", "O", "beak", "leg", "weird"]
+xlims!(ax, (-1.5,2.5))
+f #hide

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -1,0 +1,12 @@
+# # Examples
+# ## Hello to the examples page!
+using CairoMakie
+CairoMakie.activate!() # hide
+AbstractPlotting.inline!(true) # hide
+
+plot([1,2,3],[1,2,3])
+
+# maybe another one?
+x = LinRange(0, 10, 100)
+y = sin.(x)
+lines(x, y)

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -8,11 +8,12 @@ CairoMakie.activate!(type="png") # hide
 AbstractPlotting.inline!(true) # hide
 using GraphMakie
 using LightGraphs
-import Random; Random.seed!(42) # hide
+import Random; Random.seed!(2) # hide
 
 g = wheel_graph(10)
 f, ax, p = graphplot(g)
 hidedecorations!(ax); hidespines!(ax)
+ax.aspect = DataAspect()
 f # hide
 
 #=

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -1,12 +1,63 @@
-# # Examples
-# ## Hello to the examples page!
+#=
+# Plotting Graphs with `GraphMakie.jl`
+Plotting your first `AbstractGraph` from [`LightGraphs.jl`](https://juliagraphs.org/LightGraphs.jl/latest/)
+is as simple as
+=#
 using CairoMakie
-CairoMakie.activate!() # hide
+CairoMakie.activate!(type="png") # hide
 AbstractPlotting.inline!(true) # hide
+using GraphMakie
+using LightGraphs
+import Random; Random.seed!(42) # hide
 
-plot([1,2,3],[1,2,3])
+g = wheel_graph(10)
+f, ax, p = graphplot(g)
+hidedecorations!(ax); hidespines!(ax)
+f # hide
 
-# maybe another one?
-x = LinRange(0, 10, 100)
-y = sin.(x)
-lines(x, y)
+#=
+The `graphplot` command is a recipe which wraps several steps
+- layout the graph in 2D space using a layout function,
+- create a `scatter` plot for the nodes and
+- create a `linesegments` plot for the edges.
+
+The default layout is `NetworkLayout.Spring.layout` from
+[`NetworkLayout.jl`](https://github.com/JuliaGraphs/NetworkLayout.jl). The
+layout attribute can be any function which takes the adjacency matrix of the
+graph an returns a list of `(x,y)` tuples or `Point2f0` objects.
+
+Besides that there are some common attributes which are forwarded to the
+underlying plot commands. See [`graphplot(graph)`].
+=#
+using GraphMakie.NetworkLayout
+
+g = SimpleGraph(5)
+add_edge!(g, 1, 2); add_edge!(g, 2, 4);
+add_edge!(g, 4, 3); add_edge!(g, 3, 2);
+add_edge!(g, 2, 5); add_edge!(g, 5, 4);
+add_edge!(g, 4, 1); add_edge!(g, 1, 5);
+
+## define some edge colors
+edgecolors = [:black for i in 1:ne(g)]
+edgecolors[4] = edgecolors[7] = :red
+
+f, ax, p = graphplot(g, layout=NetworkLayout.Circular.layout,
+                     node_color=[:black, :red, :red, :red, :black],
+                     edge_color=edgecolors)
+
+hidedecorations!(ax); hidespines!(ax)
+ax.aspect = DataAspect()
+f #hide
+
+#=
+We can interactively change the attributes as usual with Makie.
+=#
+
+fixed_layout(_) = [(0,0), (0,1), (0.5, 1.5), (1,1), (1,0)]
+## set new layout
+p.layout = fixed_layout; autolimits!(ax)
+## change edge width & color
+p.edge_width = 5.0
+p.edge_color[][3] = :green;
+p.edge_color = p.edge_color[] # trigger observable
+f #hide

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -63,3 +63,27 @@ p.edge_width = 5.0
 p.edge_color[][3] = :green;
 p.edge_color = p.edge_color[] # trigger observable
 f #hide
+
+#=
+## Nodelabels
+=#
+Random.seed!(2)
+g = wheel_graph(10)
+
+colors = [:black for i in 1:nv(g)]
+colors[1] = :red
+
+f, ax, p = graphplot(g,
+                     nlabels=repr.(1:nv(g)),
+                     nlabels_color=colors,
+                     nlabels_align=(:center,:center))
+hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
+f # hide
+
+# This is not to nice, lets change the offsets based on the node_positions
+
+offsets = 0.10 * (p[:node_positions][] .- p[:node_positions][][1])
+offsets[1] = Point2f0(0, 0.3)
+p.nlabels_offset[] = offsets
+autolimits!(ax)
+f # hide

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,7 @@ DocMeta.setdocmeta!(GraphMakie, :DocTestSetup, :(using GraphMakie); recursive=tr
 # generate examples
 examples = [
     joinpath(@__DIR__, "examples", "plots.jl"),
+    joinpath(@__DIR__, "examples", "interactions.jl"),
 ]
 OUTPUT = joinpath(@__DIR__, "src", "generated")
 isdir(OUTPUT) && rm(OUTPUT, recursive=true)
@@ -23,7 +24,8 @@ makedocs(; modules=[GraphMakie], authors="Simon Danisch",
          format=Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true",
                                 canonical="https://JuliaPlots.github.io/GraphMakie.jl", assets=String[]),
          pages=["Home" => "index.md",
-                "Plot Examples" => "generated/plots.md"])
+                "Plot Examples" => "generated/plots.md",
+                "Interaction Examples" => "generated/interactions.md"])
 
 # if gh_pages branch gets to big, check out
 # https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#gh-pages-Branch

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,29 @@
 using GraphMakie
 using Documenter
+using Literate
+using CairoMakie
 
 DocMeta.setdocmeta!(GraphMakie, :DocTestSetup, :(using GraphMakie); recursive=true)
+
+# generate examples
+examples = [
+    joinpath(@__DIR__, "examples", "plots.jl"),
+]
+OUTPUT = joinpath(@__DIR__, "src", "generated")
+isdir(OUTPUT) && rm(OUTPUT, recursive=true)
+mkpath(OUTPUT)
+
+for ex in examples
+    Literate.markdown(ex, OUTPUT)
+end
 
 makedocs(; modules=[GraphMakie], authors="Simon Danisch",
          repo="https://github.com/JuliaPlots/GraphMakie.jl/blob/{commit}{path}#{line}",
          sitename="GraphMakie.jl",
          format=Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true",
                                 canonical="https://JuliaPlots.github.io/GraphMakie.jl", assets=String[]),
-         pages=["Home" => "index.md"])
+         pages=["Home" => "index.md",
+                "Plot Examples" => "generated/plots.md"])
 
 deploydocs(;repo="github.com/JuliaPlots/GraphMakie.jl",
            push_preview=true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,5 +25,7 @@ makedocs(; modules=[GraphMakie], authors="Simon Danisch",
          pages=["Home" => "index.md",
                 "Plot Examples" => "generated/plots.md"])
 
+# if gh_pages branch gets to big, check out
+# https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#gh-pages-Branch
 deploydocs(;repo="github.com/JuliaPlots/GraphMakie.jl",
            push_preview=true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,4 +10,5 @@ makedocs(; modules=[GraphMakie], authors="Simon Danisch",
                                 canonical="https://JuliaPlots.github.io/GraphMakie.jl", assets=String[]),
          pages=["Home" => "index.md"])
 
-deploydocs(; repo="github.com/JuliaPlots/GraphMakie.jl")
+deploydocs(;repo="github.com/JuliaPlots/GraphMakie.jl",
+           push_preview=true)

--- a/docs/servedocs
+++ b/docs/servedocs
@@ -1,0 +1,2 @@
+#!/bin/zsh
+julia -e 'using LiveServer; serve(dir="build")'

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,13 +3,40 @@ CurrentModule = GraphMakie
 ```
 
 # GraphMakie
+This is the Documentation for [GraphMakie](https://github.com/JuliaPlots/GraphMakie.jl).
 
-Documentation for [GraphMakie](https://github.com/JuliaPlots/GraphMakie.jl).
+This Package consists of two parts: a plot recipe for graphs types from
+[LightGraphs.jl](https://juliagraphs.org/LightGraphs.jl/latest/) and some helper
+functions to add interactions to those plots.
 
-```@index
+There are also [plot examples](generated/plots.md) and [interaction examples](generated/interactions.md).
 
+## `graphplot` recipe
+```@docs
+graphplot
 ```
 
-```@autodocs
-Modules = [GraphMakie]
+## Interactions
+`GraphMakie.jl` provides some helper functions to register interactions to your graph plot.
+There are special Interaction types for hovering, clicking and draging nodes and edges.
+For more information on the axis interaction please consult the [`Makie.jl` docs](https://makie.juliaplots.org/dev/makielayout/axis.html#Custom-Interactions).
+
+The general idea is to create some handler type, provide some action function and register it
+as an interaction with the axes.
+
+### Click interactions
+```@docs
+NodeClickHandler
+EdgeClickHandler
+```
+### Hover interactions
+```@docs
+NodeHoverHandler
+EdgeHoverHandler
+```
+
+### Drag interactions
+```@docs
+NodeDragHandler
+EdgeDragHandler
 ```

--- a/src/GraphMakie.jl
+++ b/src/GraphMakie.jl
@@ -5,8 +5,10 @@ using LightGraphs
 using AbstractPlotting
 using LinearAlgebra
 
+using DocStringExtensions
+import AbstractPlotting: DocThemer, ATTRIBUTES
+
 include("recipes.jl")
 include("interaction.jl")
-export plot_graph
 
 end

--- a/src/interaction.jl
+++ b/src/interaction.jl
@@ -1,52 +1,287 @@
+using AbstractPlotting: ScenePlot
+import AbstractPlotting.MakieLayout: registration_setup!, process_interaction
+
+export NodeHoverHandler, EdgeHoverHandler
+export NodeClickHandler, EdgeClickHandler
+export NodeDragHandler, EdgeDragHandler
 
 """
-    closest_point(p, positions)
-Returns the index of the point in `positions` closest to `p`
+    convert_selection(element, idx) = (element, idx)
+    convert_selection(element::LineSegments, idx) = (element, Int(idx/2))
+
+In case of `LineSegements` the reported `idx` by `pick` is allways two
+times the edge index (since LineSegments have 2 points per Line).
 """
-function closest_point(p, positions)
-    return findmin([norm(p .- v) for v in positions])
+convert_selection(element, idx) = (element, idx)
+convert_selection(element::LineSegments, idx) = (element, Int(idx/2))
+
+"""
+    abstract type GraphInteraction
+
+This abstract type supertypes other `GraphInteractions`. Some `GraphInteractions` need
+references to the scatter and linesegments plot of the `GraphPlot`. By overloding
+`set_nodeplot!(T<:GraphInteraction)` and `set_edgeplot!` those references will be set
+during `registration_setup!`.
+"""
+abstract type GraphInteraction end;
+set_nodeplot!(::GraphInteraction, plot) = nothing
+set_edgeplot!(::GraphInteraction, plot) = nothing
+
+function registration_setup!(parent, inter::GraphInteraction)
+    @assert parent isa Axis "GraphInteraction has to be registered to an Axis!"
+    # in case of multiple graph plots in one axis this won't work
+    gplots = filter(p->p isa GraphPlot, parent.scene.plots)
+    @assert length(gplots)==1 "There has to be exactly one GraphPlot in Axis!"
+
+    # in case of multiple plots of type Scatter/Linesegments in GraphPlot this won't work
+    scatter = filter(p->p isa Scatter, gplots[1].plots)
+    @assert length(scatter)==1 "There has to be exactly one Scatter-Plot in GraphPlot!"
+    set_nodeplot!(inter, scatter[1])
+
+    lines = filter(p->p isa LineSegments, gplots[1].plots)
+    @assert length(lines)==1 "There has to be exactly one LineSegments-Plot in GraphPlot!"
+    set_edgeplot!(inter, lines[1])
 end
 
-function make_axis(f::Figure)
-    ax = f[1, 1] = Axis(f; visible=false, xrectzoom=false, yrectzoom=false, leftspinevisible=false,
-                        rightspinevisible=false, topspinevisible=false, bottomspinevisible=false)
-    hidedecorations!(ax)
-    return ax
+"""
+    mutable struct HoverHandler{P<:ScenePlot, F} <: GraphInteraction
+
+Object to handle hovers on `plot::P`.
+"""
+mutable struct HoverHandler{P<:ScenePlot, F} <: GraphInteraction
+    idx::Union{Nothing, Int}
+    plot::Union{Nothing, P}
+    fun::F
 end
+set_nodeplot!(h::HoverHandler{Scatter}, plot) = h.plot = plot
+set_edgeplot!(h::HoverHandler{LineSegments}, plot) = h.plot = plot
 
-function plot_graph(g::AbstractGraph)
-    f = Figure(; resolution=(800, 800))
-    ax = make_axis(f)
+"""
+    NodeHoverHandler(fun)
 
-    # initialize for drag & drop
-    mouse_left_pressed = false
-    selected_vertex = 1
+Initializes `HoverHandler` for nodes. Calls function
 
-    graph_plot = plot!(ax, g)
-    layout_node = graph_plot.plots[2][1]
-    # handle mouse position
-    on(ax.scene.events.mouseposition) do mp
-        # offset fixes https://github.com/JuliaPlots/Makie.jl/issues/457
-        layout = layout_node[]
-        offset = Point(minimum(pixelarea(ax.scene)[]))
-        pos = to_world(ax.scene, Point(mp) .- offset)
+    fun(hoverstate, idx, event, axis)
 
-        if ispressed(ax.scene, Mouse.left)
+with `hoverstate=true` on hover and `false` at the end of hover. `idx` is the node index.
 
-            # if Mouse.left was not pressed before, select vertex
-            if !mouse_left_pressed
-                d, selected_vertex = closest_point(pos, layout)
-                d > 0.2 && return
-                mouse_left_pressed = true
+# Example
+```
+julia> g = wheel_digraph(10)
+julia> f, ax, p = graphplot(g, node_size = [20 for i in 1:nv(g)])
+julia> function action(state, idx, event, axis)
+           p.node_size[][idx] = state ? 40 : 20
+           p.node_size[] = p.node_size[] #trigger observable
+       end
+julia> register_interaction!(ax, :nodehover, NodeHoverHandler(action))
+```
+"""
+NodeHoverHandler(fun::F) where F = HoverHandler{Scatter, F}(nothing, nothing, fun)
+
+"""
+    EdgeHoverHandler(fun)
+
+Initializes `HoverHandler` for edges. Calls function
+
+    fun(hoverstate, idx, event, axis)
+
+with `hoverstate=true` on hover and `false` at the end of hover. `idx` is the edge index.
+
+# Example
+```
+julia> g = wheel_digraph(10)
+julia> f, ax, p = graphplot(g, edge_width = [3.0 for i in 1:ne(g)])
+julia> function action(state, idx, event, axis)
+           p.edge_width[][idx] = state ? 6.0 : 3.0
+           p.edge_width[] = p.edge_width[] #trigger observable
+       end
+julia> register_interaction!(ax, :edgehover, EdgeHoverHandler(action))
+```
+"""
+EdgeHoverHandler(fun::F) where F = HoverHandler{LineSegments, F}(nothing, nothing, fun)
+
+function process_interaction(handler::HoverHandler, event::MouseEvent, axis)
+    if event.type === MouseEventTypes.over
+        (element, idx) = convert_selection(mouse_selection(axis.scene)...)
+        if element == handler.plot
+            if handler.idx === nothing
+                handler.idx = idx
+                handler.fun(true, handler.idx, event, axis)
             end
-            # update the position of the selected vertex
-            layout[selected_vertex] = pos
-
-            layout_node[] = layout
         else
-            mouse_left_pressed = false
+            if handler.idx !== nothing
+                handler.fun(false, handler.idx, event, axis)
+                handler.idx = nothing
+            end
         end
     end
+end
 
-    return f
+
+"""
+    mutable struct DragHandler{P<:ScenePlot, F} <: GraphInteraction
+
+Object to handle left mous drags on `plot::P`.
+"""
+mutable struct DragHandler{P<:ScenePlot, F} <: GraphInteraction
+    idx::Union{Nothing, Int}
+    plot::Union{Nothing, P}
+    fun::F
+end
+set_nodeplot!(h::DragHandler{Scatter}, plot) = h.plot = plot
+set_edgeplot!(h::DragHandler{LineSegments}, plot) = h.plot = plot
+
+"""
+    NodeDragHandler(fun)
+
+Initializes `DragHandler` for Nodes. Calls function
+
+    fun(dragstate, idx, event, axis)
+
+where `dragstate=true` during the drag and `false` at the end of the drag,
+the last time `fun` is triggered. `idx` is the node index.
+
+# Example
+```
+julia> g = wheel_digraph(10)
+julia> f, ax, p = graphplot(g, node_size=20)
+julia> deregister_interaction!(ax, :rectanglezoom)
+julia> function action(state, idx, event, axis)
+           p[:node_positions][][idx] = event.data
+           p[:node_positions][] = p[:node_positions][]
+       end
+julia> register_interaction!(ax, :nodedrag, NodeDragHandler(action))
+```
+"""
+NodeDragHandler(fun::F) where F = DragHandler{Scatter, F}(nothing, nothing, fun)
+
+"""
+    EdgeDragHandler(fun)
+
+Initializes `DragHandler` for Edges. Calls function
+
+    fun(dragstate, idx, event, axis)
+
+where `dragstate=true` during the drag and `false` at the end of the drag,
+the last time `fun` is triggered. `idx` is the edge index.
+
+# Example
+```
+julia> g = wheel_digraph(10)
+julia> f, ax, p = graphplot(g, edge_width=3)
+julia> deregister_interaction!(ax, :rectanglezoom)
+julia> mutable struct EdgeDragAction
+           init::Union{Nothing, Point2f0} # save click position
+           src::Union{Nothing, Point2f0}  # save src vertex position
+           dst::Union{Nothing, Point2f0}  # save dst vertex position
+           EdgeDragAction() = new(nothing, nothing, nothing)
+       end
+julia> function (action::EdgeDragAction)(state, idx, event, axis)
+           edge = collect(edges(g))[idx]
+           if state == true
+               if action.src===action.dst===action.init===nothing
+                   action.init = event.data
+                   action.src = p[:node_positions][][edge.src]
+                   action.dst = p[:node_positions][][edge.dst]
+               end
+               offset = event.data - action.init
+               p[:node_positions][][edge.src] = action.src + offset
+               p[:node_positions][][edge.dst] = action.dst + offset
+               p[:node_positions][] = p[:node_positions][] # trigger change
+           elseif state == false
+               action.src = action.dst = action.init =  nothing
+           end
+       end
+julia> handler = EdgeDragHandler(EdgeDragAction())
+julia> register_interaction!(ax, :edgedrag, handler)
+```
+"""
+EdgeDragHandler(fun::F) where F = DragHandler{LineSegments, F}(nothing, nothing, fun)
+
+function process_interaction(handler::DragHandler, event::MouseEvent, axis)
+    if handler.idx === nothing # not in drag state
+        if event.type === MouseEventTypes.leftdragstart && handler.idx === nothing
+            # TODO: idealy this would take the position of the most recent leftdown event!
+            # however i am not quite sure how to use mouse_selection on px or data points
+            (element, idx) = convert_selection(mouse_selection(axis.scene)...)
+            if element === handler.plot
+                handler.idx = idx
+            end
+        end
+    elseif handler.idx !== nothing # drag state
+        if event.type === MouseEventTypes.leftdrag
+            handler.fun(true, handler.idx, event, axis)
+        elseif event.type === MouseEventTypes.leftdragstop
+            handler.fun(false, handler.idx, event, axis)
+            handler.idx = nothing
+        end
+    end
+end
+
+
+"""
+    mutable struct ClickHandler{P<:ScenePlot, F} <: GraphInteraction
+
+Object to handle left mouse clicks on `plot::P`.
+"""
+mutable struct ClickHandler{P<:ScenePlot, F} <: GraphInteraction
+    plot::Union{Nothing, P}
+    fun::F
+end
+set_nodeplot!(h::ClickHandler{Scatter}, plot) = h.plot = plot
+set_edgeplot!(h::ClickHandler{LineSegments}, plot) = h.plot = plot
+
+"""
+    NodeClickHandler(fun)
+
+Initializes `ClickHandler` for nodes. Calls function
+
+    fun(idx, event, axis)
+
+on left-click events where `idx` is the node index.
+
+# Example
+```
+julia> using AbstractPlotting.Colors
+julia> g = wheel_digraph(10)
+julia> f, ax, p = graphplot(g, node_size=30, node_color=[colorant"red" for i in 1:nv(g)])
+julia> function action(idx, event, axis)
+           p.node_color[][idx] = rand(RGB)
+           p.node_color[] = p.node_color[]
+       end
+julia> register_interaction!(ax, :nodeclick, NodeClickHandler(action))
+```
+"""
+NodeClickHandler(fun::F) where F = ClickHandler{Scatter, F}(nothing, fun)
+
+"""
+    EdgeClickHandler(fun)
+
+Initializes `ClickHandler` for edges. Calls function
+
+    fun(idx, event, axis)
+
+on left-click events where `idx` is the edge index.
+
+# Example
+```
+julia> using AbstractPlotting.Colors
+julia> g = wheel_digraph(10)
+julia> f, ax, p = graphplot(g, edge_width=4, edge_color=[colorant"black" for i in 1:ne(g)])
+julia> function action(idx, event, axis)
+           p.edge_color[][idx] = rand(RGB)
+           p.edge_color[] = p.edge_color[]
+       end
+julia> register_interaction!(ax, :edgeclick, EdgeClickHandler(action))
+```
+"""
+EdgeClickHandler(fun::F) where F = ClickHandler{LineSegments, F}(nothing, fun)
+
+function process_interaction(handler::ClickHandler, event::MouseEvent, axis)
+    if event.type === MouseEventTypes.leftclick
+        (element, idx) = convert_selection(mouse_selection(axis.scene)...)
+        if element == handler.plot
+            handler.fun(idx, event, axis)
+        end
+    end
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1,37 +1,62 @@
+"""
+    graphplot(graph::AbstractGraph)
+
+Creates a plot of the network `graph`. Consists of multiple steps:
+- Layout the nodes: the `layout` attribute is has to be a function `f(adj_matrix)::pos`
+  where `pos` is either an array of `Point2f0` or `(x, y)` tuples
+- plot edges as `linesegments`-plot
+- plot nodes as `scatter`-plot
+
+The main attributes for the subplots are exposed as attributes for `graphplot`.
+Additional attributes for the `scatter` or `linesegments` plots can be provided
+as a named tuples to `node_attr` and `edge_attr`.
+
+## Attributes
+$(ATTRIBUTES)
+"""
 @recipe(GraphPlot, graph) do scene
+    scatter_theme = default_theme(scene, Scatter)
+    lineseg_theme = default_theme(scene, LineSegments)
     Attributes(
         layout = NetworkLayout.Spring.layout,
-        nodecolor = :red,
-        nodesize = 20,
-        marker = :circle,
-        edgecolor = :black,
-        edgewidth = 2.5,
+        node_color = scatter_theme.color,
+        node_size = scatter_theme.markersize,
+        node_marker = scatter_theme.marker,
+        node_attr = (;),
+        edge_color = lineseg_theme.color,
+        edge_width = lineseg_theme.linewidth,
+        edge_attr = (;),
     )
 end
 
 function AbstractPlotting.plot!(gp::GraphPlot)
     graph = gp[:graph]
 
-    # create initial vertex positions
-    node_points = @lift begin
+    # create initial vertex positions, will be updated on changes to graph or layout
+    node_positions = @lift begin
         A = adjacency_matrix($graph)
-        ($(gp.layout))(A) # array of Point2f0
+        [Point2f0(p) for p in ($(gp.layout))(A)]
     end
 
+    # create views into the node_positions, will be updated node_position changes
+    # in case of a graph change the node_position will change anyway
     edge_segments = @lift begin
-        indices = vec([getfield(e, s) for s in (:src, :dst), e in edges($graph)])
-        view($node_points, indices)
+        indices = vec([getfield(e, s) for s in (:src, :dst), e in edges(graph[])])
+        ($node_positions)[indices]
     end
+    @info "edges" edge_segments edge_segments[] gp.edge_color[]
 
     # plot edges
-    edge_plot = linesegments!(gp, edge_segments,
-                              color=gp.edgecolor,
-                              linewidth=gp.edgewidth)
+    edge_plot = linesegments!(gp, edge_segments;
+                              color=gp.edge_color,
+                              linewidth=gp.edge_width,
+                              gp.edge_attr...)
 
     # plot vertices
-    vertex_plot = scatter!(gp, node_points,
-                           color=gp.nodecolor,
-                           marker=gp.marker,
-                           markersize=gp.nodesize)
+    vertex_plot = scatter!(gp, node_positions;
+                           color=gp.node_color,
+                           marker=gp.node_marker,
+                           markersize=gp.node_size,
+                           gp.node_attr...)
     return gp
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1,32 +1,37 @@
+@recipe(GraphPlot, graph) do scene
+    Attributes(
+        layout = NetworkLayout.Spring.layout,
+        nodecolor = :red,
+        nodesize = 20,
+        marker = :circle,
+        edgecolor = :black,
+        edgewidth = 2.5,
+    )
+end
 
-function AbstractPlotting.plot!(graph_plot::Combined{Any,S} where {S<:Tuple{<:AbstractGraph}})
+function AbstractPlotting.plot!(gp::GraphPlot)
+    graph = gp[:graph]
+
     # create initial vertex positions
-    graph = graph_plot[1]
-    layout_node = map(graph) do graph
-        A = adjacency_matrix(graph)
-        return [Point2f0(p[1], p[2]) for p in NetworkLayout.Spring.layout(A)]
+    node_points = @lift begin
+        A = adjacency_matrix($graph)
+        ($(gp.layout))(A) # array of Point2f0
     end
+
+    edge_segments = @lift begin
+        indices = vec([getfield(e, s) for s in (:src, :dst), e in edges($graph)])
+        view($node_points, indices)
+    end
+
+    # plot edges
+    edge_plot = linesegments!(gp, edge_segments,
+                              color=gp.edgecolor,
+                              linewidth=gp.edgewidth)
 
     # plot vertices
-    vertex_plot = scatter!(graph_plot, layout_node)
-    # plot edges
-    lines = map(vertex_plot[1]) do x
-        indices = vec([getfield(e, src) for src in (:src, :dst), e in edges(graph[])])
-        return view(x, indices)
-    end
-    linesegments!(graph_plot, lines)
-    # Plot vertices over lines
-    reverse!(graph_plot.plots)
-
-    labels = get(graph_plot, :labels, Observable(nothing))
-    if !isnothing(labels[])
-        labels_pos = map(vertex_plot[1], labels) do positions, labels
-            if length(positions) != length(labels)
-                error("Need one label per vertex. Found $(length(labels)) labels and $(length(positions)) vertices.")
-            end
-            return map((a, b)-> (a, b), labels, positions)
-        end
-    end
-
-    return graph_plot
+    vertex_plot = scatter!(gp, node_points,
+                           color=gp.nodecolor,
+                           marker=gp.marker,
+                           markersize=gp.nodesize)
+    return gp
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -33,10 +33,13 @@ function AbstractPlotting.plot!(gp::GraphPlot)
     graph = gp[:graph]
 
     # create initial vertex positions, will be updated on changes to graph or layout
-    node_positions = @lift begin
+    # make node_position-Observable available as named attribute from the outside
+    gp[:node_positions] = @lift begin
         A = adjacency_matrix($graph)
         [Point2f0(p) for p in ($(gp.layout))(A)]
     end
+
+    node_positions = gp[:node_positions]
 
     # create views into the node_positions, will be updated node_position changes
     # in case of a graph change the node_position will change anyway

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1,5 +1,8 @@
+export GraphPlot, graphplot, graphplot!
+
 """
     graphplot(graph::AbstractGraph)
+    graphplot!(ax, graph::AbstractGraph)
 
 Creates a plot of the network `graph`. Consists of multiple steps:
 - Layout the nodes: the `layout` attribute is has to be a function `f(adj_matrix)::pos`

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -44,12 +44,19 @@ function AbstractPlotting.plot!(gp::GraphPlot)
         indices = vec([getfield(e, s) for s in (:src, :dst), e in edges(graph[])])
         ($node_positions)[indices]
     end
-    @info "edges" edge_segments edge_segments[] gp.edge_color[]
+
+    # in case the edge_with is same as the number of edges
+    # create a new observable which doubles the values for compat with line segments
+    if length(gp.edge_width[]) == ne(graph[])
+        lineseg_width = @lift repeat($(gp.edge_width), inner=2)
+    else
+        lineseg_width = gp.edge_width
+    end
 
     # plot edges
     edge_plot = linesegments!(gp, edge_segments;
                               color=gp.edge_color,
-                              linewidth=gp.edge_width,
+                              linewidth=lineseg_width,
                               gp.edge_attr...)
 
     # plot vertices

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -10,10 +10,11 @@ Creates a plot of the network `graph`. Consists of multiple steps:
 - plot edges as `linesegments`-plot
 - plot nodes as `scatter`-plot
 - if `nlabels!=nothing` plot node labels as `text`-plot
+- if `elabels!=nothing` plot edge labels as `text`-plot
 
 The main attributes for the subplots are exposed as attributes for `graphplot`.
 Additional attributes for the `scatter`, `linesegments` and `text` plots can be provided
-as a named tuples to `node_attr`, `edge_attr`, `nlabels_attr` ,...
+as a named tuples to `node_attr`, `edge_attr`, `nlabels_attr` and `elabels_attr`.
 
 Most of the arguments can be either given as a vector of length of the
 edges/nodes or as a single value. One might run into errors when changing the
@@ -29,6 +30,7 @@ $(ATTRIBUTES)
     Attributes(
         layout = NetworkLayout.Spring.layout,
         nlabels = nothing,
+        elabels = nothing,
         # node attributes (Scatter)
         node_color = scatter_theme.color,
         node_size = scatter_theme.markersize,
@@ -44,6 +46,16 @@ $(ATTRIBUTES)
         nlabels_offset = Point2f0(0.0, 0.0),
         nlabels_textsize = labels_theme.textsize,
         nlabels_attr = (;),
+        # edge label attributes (Text)
+        elabels_align = (:center, :bottom),
+        elabels_color = labels_theme.color,
+        elabels_distance = 0.0,
+        elabels_shift = 0.0,
+        elabels_offset = Point2f0(0.0, 0.0),
+        elabels_rotation = nothing,
+        elabels_opposite = Int[],
+        elabels_textsize = labels_theme.textsize,
+        elabels_attr = (;),
     )
 end
 
@@ -96,6 +108,55 @@ function AbstractPlotting.plot!(gp::GraphPlot)
                              color=gp.nlabels_color,
                              textsize=gp.nlabels_textsize,
                              gp.nlabels_attr...)
+    end
+
+    # plot edge labels
+    if gp.elabels[] !== nothing
+        # calculate the vectors for each edge
+        edge_vec = lift(edge_segments, graph) do seg, g
+            [seg[2i] - seg[2i-1] for i in 1:ne(g)]
+        end
+
+        # rotations based on the edge_vec and opposite argument
+        rotations = @lift begin
+            if $(gp.elabels_rotation) isa Real
+                # fix rotation to a signle angle
+                rot = [$(gp.elabels_rotation) for i in 1:ne($graph)]
+            else
+                # determine rotation by edge vector
+                rot = map(v -> atan(v.data[2], v.data[1]), $edge_vec)
+                for i in $(gp.elabels_opposite)
+                    rot[i] += π
+                end
+                # if there are user provided rotations for some labels, use those
+                if $(gp.elabels_rotation) isa Vector
+                    for (i, α) in enumerate($(gp.elabels_rotation))
+                        α !== nothing && (rot[i] = α)
+                    end
+                end
+            end
+            return rot
+        end
+
+        # calculate the normal vectors for the distance
+        # this needs to be recalculated from angle because the angle is user provided
+        edge_dir = @lift map(α -> Point2f0(cos(α), sin(α)), $rotations)
+        normal_dir = @lift map(p -> Point2f0(-p.data[2], p.data[1]), $edge_dir)
+
+        # positions: center point between nodes + offset + distance*normal + shift*edge direction
+        positions = @lift begin
+            pos = [($edge_segments[2i-1] + $edge_segments[2i])/2 for i in 1:ne($graph)]
+            pos .= pos .+ $(gp.elabels_offset)
+            pos .= pos .+ $(gp.elabels_distance) .* $normal_dir .+ $(gp.elabels_shift) .* $edge_dir
+        end
+
+        elabels_plot = text!(gp, gp.elabels;
+                             position=positions,
+                             rotation=rotations,
+                             align=gp.elabels_align,
+                             color=gp.elabels_color,
+                             textsize=gp.elabels_textsize,
+                             gp.elabels_attr...)
     end
 
     return gp

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using GLMakie
+using CairoMakie
 using GraphMakie
 using GraphMakie.LightGraphs
 using GraphMakie.AbstractPlotting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,30 @@
+using GLMakie
 using GraphMakie
 using GraphMakie.LightGraphs
 using GraphMakie.AbstractPlotting
+using NetworkLayout
 using Test
 
 @testset "GraphMakie.jl" begin
-    g = wheel_digraph(10)
-    f, ax, p = plot(g)
-    f = plot_graph(g)
+    g = Node(wheel_digraph(10))
+    f, ax, p = graphplot(g)
+
+    # try to update graph
+    add_edge!(g[], 2, 4)
+    g[] = g[]
+    # try to update network
+    p.layout = NetworkLayout.SFDP.layout
+    # TODO: viewport stays constant uppon changing of g and layout, is this desired?
+
+    # update node observables
+    p.nodecolor = :blue
+    p.nodesize = 30
+    p.marker = :rect
+
+    # update edge observables
+    p.edgewidth = 5.0
+    p.edgecolor = :green
+
+    # it should be also possible to pass multiple values
+    f, ax, p = graphplot(g, nodecolor=[rand([:blue,:red,:green]) for i in 1:nv(g[])])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using CairoMakie
 using GraphMakie
 using GraphMakie.LightGraphs
 using GraphMakie.NetworkLayout
+using AbstractPlotting.Colors
+# using GLMakie
 using Test
 
 @testset "GraphMakie.jl" begin
@@ -19,7 +21,6 @@ using Test
     g[] = g[]
     # try to update network
     p.layout = NetworkLayout.SFDP.layout
-    # TODO: viewport stays constant uppon changing of g and layout, is this desired?
 
     # update node observables
     p.nodecolor = :blue
@@ -32,4 +33,74 @@ using Test
 
     # it should be also possible to pass multiple values
     f, ax, p = graphplot(g, nodecolor=[rand([:blue,:red,:green]) for i in 1:nv(g[])])
+end
+
+@testset "Hover, click and drag Interaction" begin
+    g = wheel_digraph(10)
+    f, ax, p = graphplot(g,
+                         edge_width = [3.0 for i in 1:ne(g)],
+                         edge_color = [colorant"black" for i in 1:ne(g)],
+                         node_size = [20 for i in 1:nv(g)],
+                         node_color = [colorant"red" for i in 1:nv(g)])
+    deregister_interaction!(ax, :rectanglezoom)
+
+    function edge_hover_action(s, idx, event, axis)
+        p.edge_width[][idx]= s ? 6.0 : 3.0
+        p.edge_width[] = p.edge_width[] # trigger observable
+    end
+    ehover = EdgeHoverHandler(edge_hover_action)
+    register_interaction!(ax, :ehover, ehover)
+
+    function node_hover_action(s, idx, event, axis)
+        p.node_size[][idx] = s ? 40 : 20
+        p.node_size[] = p.node_size[] # trigger observable
+    end
+    nhover = NodeHoverHandler(node_hover_action)
+    register_interaction!(ax, :nhover, nhover)
+
+    function node_click_action(idx, args...)
+        p.node_color[][idx] = rand(RGB)
+        p.node_color[] = p.node_color[]
+    end
+    nclick = NodeClickHandler(node_click_action)
+    register_interaction!(ax, :nclick, nclick)
+
+    function edge_click_action(idx, args...)
+        p.edge_color[][idx] = rand(RGB)
+        p.edge_color[] = p.edge_color[]
+    end
+    eclick = EdgeClickHandler(edge_click_action)
+    register_interaction!(ax, :eclick, eclick)
+
+    function node_drag_action(state, idx, event, axis)
+        p[:node_positions][][idx] = event.data
+        p[:node_positions][] = p[:node_positions][]
+    end
+    ndrag = NodeDragHandler(node_drag_action)
+    register_interaction!(ax, :ndrag, ndrag)
+
+    mutable struct EdgeDragAction
+        init::Union{Nothing, Point2f0} # save click position
+        src::Union{Nothing, Point2f0}  # save src vertex position
+        dst::Union{Nothing, Point2f0}  # save dst vertex position
+        EdgeDragAction() = new(nothing, nothing, nothing)
+    end
+    function (action::EdgeDragAction)(state, idx, event, axis)
+        edge = collect(edges(g))[idx]
+        if state == true
+            if action.src===action.dst===action.init===nothing
+                action.init = event.data
+                action.src = p[:node_positions][][edge.src]
+                action.dst = p[:node_positions][][edge.dst]
+            end
+            offset = event.data - action.init
+            p[:node_positions][][edge.src] = action.src + offset
+            p[:node_positions][][edge.dst] = action.dst + offset
+            p[:node_positions][] = p[:node_positions][] # trigger change
+        elseif state == false
+            action.src = action.dst = action.init =  nothing
+        end
+    end
+    edrag = EdgeDragHandler(EdgeDragAction())
+    register_interaction!(ax, :edrag, edrag)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,18 @@
 using CairoMakie
 using GraphMakie
 using GraphMakie.LightGraphs
-using GraphMakie.AbstractPlotting
-using NetworkLayout
+using GraphMakie.NetworkLayout
 using Test
 
 @testset "GraphMakie.jl" begin
     g = Node(wheel_digraph(10))
     f, ax, p = graphplot(g)
+    f, ax, p = graphplot(g, node_attr=Attributes(visible=false))
+    f, ax, p = graphplot(g, node_attr=(;visible=false))
+
+    a = Attributes(visible=true)
+    scatter([1,2,3], [4,1,2])
+    scatter!([1,2,3], [1,2,3]; visible=true, a...)
 
     # try to update graph
     add_edge!(g[], 2, 4)


### PR DESCRIPTION
I've started by adding some explicit attributes to the recipe
- `layout`, some function `f(A)::Vector{Point2f0}` where `A` is the adjacency matrix
- `nodecolor` gets passed as color to `scatter!`
- `nodesize` gets passed as markersize to `scatter!` 
- `marker` gets passed as `marker` to `scatter!`
- `edgecolor` gets passed as color to `linesegments!`
- `edgewidth` gets passed as linewidth to `linesegments`

things todo:
- [x] node labels
- [x] edge labels
- [x] figure out some meaningful way of testing -> docs for now
- [x] optional attributes for additional kw arguments for the different internal plot commands? (something like `graphplot(g, lineplotkw=(linestyle=..., ...))`
- ~~layouts: the `layout` function should enclose the random seeds and so on, otherwise the plots are not consistent/reproducible.s~~ will become PR in `NetworkLayout.jl`

