### PR TITLE
proper edge labels

### DIFF
--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -129,9 +129,9 @@ p.elabels_offset[] = [Point2f0(0.0, 0.0) for i in 1:ne(g)]
 p.elabels_offset[][5] = Point2f0(-0.4,0)
 p.elabels_offset[] = p.elabels_offset[]
 
-p.elabels_shift[] = zeros(ne(g))
-p.elabels_shift[][4] = -.5
-p.elabels_shift[][3] = +.2
+p.elabels_shift[] = [0.5 for i in 1:ne(g)]
+p.elabels_shift[][4] = 0.7
+p.elabels_shift[][3] = 0.6
 p.elabels_shift[] = p.elabels_shift[]
 
 p.elabels_distance[] = zeros(ne(g))

--- a/src/GraphMakie.jl
+++ b/src/GraphMakie.jl
@@ -6,7 +6,7 @@ using Makie
 using LinearAlgebra
 
 using DocStringExtensions
-import Makie: DocThemer, ATTRIBUTES
+import Makie: DocThemer, ATTRIBUTES, project
 
 include("recipes.jl")
 include("interaction.jl")

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -89,12 +89,12 @@ the edge.
         # edge label attributes (Text)
         elabels = nothing,
         elabels_align = (:center, :bottom),
-        elabels_color = labels_theme.color,
         elabels_distance = 0.0,
         elabels_shift = 0.5,
-        elabels_offset = nothing,
-        elabels_rotation = nothing,
         elabels_opposite = Int[],
+        elabels_rotation = nothing,
+        elabels_offset = nothing,
+        elabels_color = labels_theme.color,
         elabels_textsize = labels_theme.textsize,
         elabels_attr = (;),
     )


### PR DESCRIPTION
- angle of text gets calculated in screen space now, i.e. independent of aspect ratio
- nice side effect: also works in 3d now, including rotation of the scene and stuff :)
<img width="537" alt="grafik" src="https://user-images.githubusercontent.com/35867212/120073994-f3a36380-c09a-11eb-9a6e-b5429fe1e039.png">

- documentaion on this could be better but i think i'll need to overhaul some of the docs anyway as soon as `NetworkLayouts@0.4` is ready
