### PR TITLE
Arrowheads for DiGraph & improved interactions

### DIFF
--- a/docs/examples/interactions.jl
+++ b/docs/examples/interactions.jl
@@ -14,7 +14,7 @@ using LightGraphs
 using CairoMakie.Colors
 
 import Random; Random.seed!(2) # hide
-g = wheel_digraph(10)
+g = wheel_graph(10)
 f, ax, p = graphplot(g,
                      edge_width = [2.0 for i in 1:ne(g)],
                      edge_color = [colorant"gray" for i in 1:ne(g)],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,9 +9,9 @@ This Package consists of two parts: a plot recipe for graphs types from
 [LightGraphs.jl](https://juliagraphs.org/LightGraphs.jl/latest/) and some helper
 functions to add interactions to those plots.
 
-There are also [plot examples](generated/plots.md) and [interaction examples](generated/interactions.md).
+There are also [plot examples](generated/plots.md) and [interaction examples](generated/interactions.md) pages.
 
-## `graphplot` recipe
+## The `graphplot` Recipe
 ```@docs
 graphplot
 ```
@@ -24,18 +24,18 @@ For more information on the axis interaction please consult the [`Makie.jl` docs
 The general idea is to create some handler type, provide some action function and register it
 as an interaction with the axes.
 
-### Click interactions
+### Click Interactions
 ```@docs
 NodeClickHandler
 EdgeClickHandler
 ```
-### Hover interactions
+### Hover Interactions
 ```@docs
 NodeHoverHandler
 EdgeHoverHandler
 ```
 
-### Drag interactions
+### Drag Interactions
 ```@docs
 NodeDragHandler
 EdgeDragHandler

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,9 +16,35 @@ There are also [plot examples](generated/plots.md) and [interaction examples](ge
 graphplot
 ```
 
-## Interactions
+## Predefined Interactions
+`GraphMakie.jl` provides some pre-built interactions to enable drag&drop of nodes and edges as well as highlight on hover.
+
+To try them all use the following code in a `GLMakie` environment.
+```julia
+using GLMakie
+using GraphMakie
+using LightGraphs
+g = wheel_graph(10)
+f, ax, p = graphplot(g, edge_width=[3 for i in 1:ne(g)],
+                     node_size=[10 for i in 1:nv(g)])
+
+deregister_interaction!(ax, :rectanglezoom)
+register_interaction!(ax, :nhover, NodeHoverHighlight(p))
+register_interaction!(ax, :ehover, EdgeHoverHighlight(p))
+register_interaction!(ax, :ndrag, NodeDrag(p))
+register_interaction!(ax, :edrag, EdgeDrag(p))
+```
+
+```@docs
+NodeHoverHighlight
+EdgeHoverHighlight
+NodeDrag
+EdgeDrag
+```
+
+## Interaction Interface
 `GraphMakie.jl` provides some helper functions to register interactions to your graph plot.
-There are special Interaction types for hovering, clicking and draging nodes and edges.
+There are special interaction types for hovering, clicking and draging nodes and edges.
 For more information on the axis interaction please consult the [`Makie.jl` docs](https://makie.juliaplots.org/dev/makielayout/axis.html#Custom-Interactions).
 
 The general idea is to create some handler type, provide some action function and register it

--- a/src/GraphMakie.jl
+++ b/src/GraphMakie.jl
@@ -6,7 +6,7 @@ using Makie
 using LinearAlgebra
 
 using DocStringExtensions
-import Makie: DocThemer, ATTRIBUTES, project
+import Makie: DocThemer, ATTRIBUTES, project, automatic
 
 include("recipes.jl")
 include("interaction.jl")

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -36,6 +36,7 @@ underlying graph and therefore changing the number of Edges/Nodes.
   Defaults to `true` for `SimpleDiGraph` and `false` otherwise.
 - `arrow_size=scatter_theme.markersize`: Size of arrowheads.
 - `arrow_shift=0.5`: Shift arrow position from source (0) to dest (1) node.
+- `arrow_attr=(;)`: List of kw arguments which gets passed to the `scatter` command
 
 ### Node labels
 The position of each label is determined by the node position plus an offset in
@@ -83,9 +84,11 @@ the edge.
         edge_color = lineseg_theme.color,
         edge_width = lineseg_theme.linewidth,
         edge_attr = (;),
+        # arrow attributes (Scatter)
         arrow_show = automatic,
         arrow_size = scatter_theme.markersize,
         arrow_shift = 0.5,
+        arrow_attr = (;),
         # node label attributes (Text)
         nlabels = nothing,
         nlabels_align = (:left, :bottom),
@@ -166,7 +169,8 @@ function Makie.plot!(gp::GraphPlot)
                                rotations = @lift(Billboard($edge_rotations_px)),
                                strokewidth = 0.0,
                                markerspace = Pixel,
-                               visible = arrow_show)
+                               visible = arrow_show,
+                               gp.arrow_attr...)
     end
 
     # plot vertices

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -154,15 +154,20 @@ function Makie.plot!(gp::GraphPlot)
     arrow_pos = @lift $edge_pos[1] .+ $(gp.arrow_shift) .* ($edge_pos[2] .- $edge_pos[1])
     arrow_show = @lift $(gp.arrow_show) === automatic ? $graph isa SimpleDiGraph : $(gp.arrow_show)
 
-    arrow_heads = scatter!(gp,
-                           arrow_pos,
-                           marker = '➤',
-                           markersize = gp.arrow_size,
-                           color = gp.edge_color,
-                           rotations = @lift(Billboard($edge_rotations_px)),
-                           strokewidth = 0.0,
-                           markerspace = Pixel,
-                           visible = arrow_show)
+    # hotfix for https://github.com/JuliaPlots/Makie.jl/issues/1018
+    # don't plot if arrow_show=false and Cairo
+    iscairo = repr(typeof(Makie.current_backend[])) == "CairoMakie.CairoBackend"
+    if !iscairo || (iscairo && arrow_show[])
+        arrow_heads = scatter!(gp,
+                               arrow_pos,
+                               marker = '➤',
+                               markersize = gp.arrow_size,
+                               color = gp.edge_color,
+                               rotations = @lift(Billboard($edge_rotations_px)),
+                               strokewidth = 0.0,
+                               markerspace = Pixel,
+                               visible = arrow_show)
+    end
 
     # plot vertices
     vertex_plot = scatter!(gp, node_pos;

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -32,6 +32,10 @@ underlying graph and therefore changing the number of Edges/Nodes.
 - `edge_width=lineseg_theme.linewidth`: Pass a vector with 2 width per edge to
   get pointy edges.
 - `edge_attr=(;)`: List of kw arguments which gets passed to the `linesegments` command
+- `arrow_show=Makie.automatic`: `Bool`, indicate edge directions with arrowheads?
+  Defaults to `true` for `SimpleDiGraph` and `false` otherwise.
+- `arrow_size=scatter_theme.markersize`: Size of arrowheads.
+- `arrow_shift=0.5`: Shift arrow position from source (0) to dest (1) node.
 
 ### Node labels
 The position of each label is determined by the node position plus an offset in

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -44,6 +44,7 @@ data space.
 
 - `nlabels=nothing`: `Vector{String}` with label for each node
 - `nlabels_align=(:left, :bottom)`: Anchor of text field.
+- `nlabels_distance=0.0`: Pixel distance from node in direction of align.
 - `nlabels_color=labels_theme.color`
 - `nlabels_offset=nothing`: `Point` or `Vector{Point}`
 - `nlabels_textsize=labels_theme.textsize`
@@ -92,6 +93,7 @@ the edge.
         # node label attributes (Text)
         nlabels = nothing,
         nlabels_align = (:left, :bottom),
+        nlabels_distance = 0.0,
         nlabels_color = labels_theme.color,
         nlabels_offset = nothing,
         nlabels_textsize = labels_theme.textsize,
@@ -189,10 +191,12 @@ function Makie.plot!(gp::GraphPlot)
                 copy($node_pos)
             end
         end
+        offset = @lift $(gp.nlabels_distance) .* align_to_dir.($(gp.nlabels_align))
         nlabels_plot = text!(gp, gp.nlabels;
                              position=positions,
                              align=gp.nlabels_align,
                              color=gp.nlabels_color,
+                             offset=offset,
                              textsize=gp.nlabels_textsize,
                              gp.nlabels_attr...)
     end
@@ -247,4 +251,24 @@ function Makie.plot!(gp::GraphPlot)
     end
 
     return gp
+end
+
+function align_to_dir(align)
+    halign, valign = align
+
+    x = 0.0
+    if halign === :left
+        x = 1.0
+    elseif halign === :right
+        x = -1.0
+    end
+
+    y = 0.0
+    if valign === :top
+        y = -1.0
+    elseif valign === :bottom
+        y = 1.0
+    end
+    norm = x==y==0.0 ? 1 : sqrt(x^2 + y^2)
+    return Point(x/norm, y/norm)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,11 +10,7 @@ using Test
     g = Node(wheel_digraph(10))
     f, ax, p = graphplot(g)
     f, ax, p = graphplot(g, node_attr=Attributes(visible=false))
-    f, ax, p = graphplot(g, node_attr=(;visible=false))
-
-    a = Attributes(visible=true)
-    scatter([1,2,3], [4,1,2])
-    scatter!([1,2,3], [1,2,3]; visible=true, a...)
+    f, ax, p = graphplot(g, node_attr=(;visible=true))
 
     # try to update graph
     add_edge!(g[], 2, 4)
@@ -23,16 +19,15 @@ using Test
     p.layout = NetworkLayout.SFDP.layout
 
     # update node observables
-    p.nodecolor = :blue
-    p.nodesize = 30
-    p.marker = :rect
+    p.node_color = :blue
+    p.node_size = 30
 
     # update edge observables
-    p.edgewidth = 5.0
-    p.edgecolor = :green
+    p.edge_width = 5.0
+    p.edge_color = :green
 
     # it should be also possible to pass multiple values
-    f, ax, p = graphplot(g, nodecolor=[rand([:blue,:red,:green]) for i in 1:nv(g[])])
+    f, ax, p = graphplot(g, node_color=[rand([:blue,:red,:green]) for i in 1:nv(g[])])
 end
 
 @testset "Hover, click and drag Interaction" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,3 +99,26 @@ end
     edrag = EdgeDragHandler(EdgeDragAction())
     register_interaction!(ax, :edrag, edrag)
 end
+
+@testset "align_to_direction" begin
+    using GraphMakie: align_to_dir
+    using LinearAlgebra: normalize
+
+    @test align_to_dir((:left, :center)) == Point(1.0, 0)
+    @test align_to_dir((:right, :center)) == Point(-1.0, 0)
+    @test align_to_dir((:center, :center)) == Point(0.0, 0)
+
+    @test align_to_dir((:left, :top)) == normalize(Point(1.0, -1.0))
+    @test align_to_dir((:right, :top)) == normalize(Point(-1.0, -1))
+    @test align_to_dir((:center, :top)) == normalize(Point(0.0, -1))
+
+    @test align_to_dir((:left, :bottom)) == normalize(Point(1.0, 1.0))
+    @test align_to_dir((:right, :bottom)) == normalize(Point(-1.0, 1.0))
+    @test align_to_dir((:center, :bottom)) == normalize(Point(0.0, 1.0))
+
+    # g = complete_graph(9)
+    # nlabels_align = vec(collect(Iterators.product((:left,:center,:right),(:top,:center,:bottom))))
+    # nlabels= repr.(nlabels_align)
+    # graphplot(g; nlabels, nlabels_align, nlabels_distance=20)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ using Test
 end
 
 @testset "Hover, click and drag Interaction" begin
-    g = wheel_digraph(10)
+    g = wheel_graph(10)
     f, ax, p = graphplot(g,
                          edge_width = [3.0 for i in 1:ne(g)],
                          edge_color = [colorant"black" for i in 1:ne(g)],


### PR DESCRIPTION
Simple implementation of arrowheads as edge-direction indication. At some point we might want to go full [`arrows`](https://makie.juliaplots.org/dev/plotting_functions/arrows.html) but this would lead to divergence between the codes with and without arrowheads.

Right know, I'd say the same projection trick as with the edge labels works quite well in 2D and 3D.

This feature is not yet shown in the docs beside the docstring. Once again, I'll rework the docs for `NetworkLayout@0.4`.

<img width="700" alt="grafik" src="https://user-images.githubusercontent.com/35867212/120324737-3f4a4d00-c2e7-11eb-87af-909608b49a36.png">
<img width="700" alt="grafik" src="https://user-images.githubusercontent.com/35867212/120324688-30fc3100-c2e7-11eb-8ea8-df99fc877fba.png">
