### PR TITLE
Draw edges as bezier curves

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,19 @@ authors = ["Simon Danisch", "Hans Würfel"]
 version = "0.2.2"
 
 [deps]
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 NetworkLayout = "46757867-2c16-5918-afeb-47bfcb05e46a"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+GeometryBasics = "0.3"
 LightGraphs = "1.3"
 Makie = "0.15"
 NetworkLayout = "0.4"
+StaticArrays = "1.2"
 julia = "1"
 
 [extras]

--- a/docs/examples/depgraph.jl
+++ b/docs/examples/depgraph.jl
@@ -52,6 +52,10 @@ dependency tree.
 (packages, g) = depgraph("Revise")
 N = length(packages)
 xs, ys, paths = solve_positions(Zarate(), g)
+
+## we scale the y coordinates so the plot looks nice in `DataAspect()`
+ys .= 0.3 .* ys
+foreach(v -> v[2] .= 0.3 .* v[2], values(paths))
 nothing #hide
 
 #=
@@ -84,10 +88,11 @@ f, ax, p = graphplot(g; layout=lay,
                      nlabels_offset=offset,
                      node_size=[9.0 for i in 1:N],
                      edge_width=[3 for i in 1:ne(g)],
-                     waypoints=wp)
+                     waypoints=wp,
+                     waypoint_radius=0.5)
 ax.title = "Dependency Graph of Revise.jl"
 xlims!(ax, -0.6, 5.6)
-hidedecorations!(ax); hidespines!(ax)
+hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
 f #hide
 
 #=

--- a/docs/examples/depgraph.jl
+++ b/docs/examples/depgraph.jl
@@ -55,22 +55,24 @@ xs, ys, paths = solve_positions(Zarate(), g)
 nothing #hide
 
 #=
-In `GraphMakie` the layout allways needs to be function. So we're creating a dummy function...
-At the moment, `GraphMakie` can not make use of the nice `paths` property (which would add
-additional waypoints to the edges).
+In `GraphMakie` the layout always needs to be function. So we're creating a dummy function...
+We will use the [Edge waypoints](@ref) attribute to get the graph with the least crossings.
 =#
 lay = _ -> Point.(zip(xs,ys))
+## create a vector of Point2f0 per edge
+wp = [Point2f0.(zip(paths[e]...)) for e in edges(g)]
 
 ## manually tweak some of the lable aligns
 align = [(:right, :center) for i in 1:N]
-align[1] = (:left, :center)
-align[3] = align[13] = (:left, :top)
-align[6] = (:center, :bottom)
-align[10] = (:right, :top)
+align[1]  = (:left, :center)  # Revise
+align[3]  = (:right, :top)    # LoweredCodeUtils
+align[6]  = (:left, :bottom)  # CodeTracking
+align[10] = (:left, :bottom)  # JuliaInterpreter
+align[13] = (:left, :bottom)  # Requires
 
-## shift "CodeTracking" node in data space
+## shift "JuliaInterpreter" node in data space
 offset = [Point2f0(0,0) for i in 1:N]
-offset[6] = Point(0.0, 0.4)
+offset[10] = Point(-0.1, 0.1)
 
 f, ax, p = graphplot(g; layout=lay,
                      arrow_size=15,
@@ -78,9 +80,11 @@ f, ax, p = graphplot(g; layout=lay,
                      nlabels=packages,
                      nlabels_align=align,
                      nlabels_distance=10,
+                     nlabels_textsize=15,
                      nlabels_offset=offset,
                      node_size=[9.0 for i in 1:N],
-                     edge_width=[3 for i in 1:ne(g)])
+                     edge_width=[3 for i in 1:ne(g)],
+                     waypoints=wp)
 ax.title = "Dependency Graph of Revise.jl"
 xlims!(ax, -0.6, 5.6)
 hidedecorations!(ax); hidespines!(ax)

--- a/docs/examples/interactions.jl
+++ b/docs/examples/interactions.jl
@@ -49,7 +49,7 @@ function set_cursor!(p) #hide
     direction = Point2f0(-0.1, 0.2) #hide
     arrows!([p-direction], [direction], linewidth=3, arrowsize=20, lengthscale=0.8) #hide
 end #hide
-nodepos = copy(p[:node_positions][]) #hide
+nodepos = copy(p[:node_pos][]) #hide
 set_cursor!(nodepos[5] + Point2f0(0.05, 0)) #hide
 p.node_size[][5] = 20; p.node_size[] = p.node_size[] #hide
 f #hide
@@ -99,15 +99,15 @@ f #hide
 pop!(ax.scene.plots) #hide
 p.edge_width[][3] = 2.0; p.edge_width[] = p.edge_width[] #hide
 function node_drag_action(state, idx, event, axis)
-    p[:node_positions][][idx] = event.data
-    p[:node_positions][] = p[:node_positions][]
+    p[:node_pos][][idx] = event.data
+    p[:node_pos][] = p[:node_pos][]
 end
 ndrag = NodeDragHandler(node_drag_action)
 register_interaction!(ax, :ndrag, ndrag)
 
-p[:node_positions][][1] = nodepos[1] + Point2f0(1.0,0.5) #hide
-p[:node_positions][] = p[:node_positions][] #hide
-set_cursor!(p[:node_positions][][1] + Point2f0(0.05, 0)) #hide
+p[:node_pos][][1] = nodepos[1] + Point2f0(1.0,0.5) #hide
+p[:node_pos][] = p[:node_pos][] #hide
+set_cursor!(p[:node_pos][][1] + Point2f0(0.05, 0)) #hide
 p.node_size[][1] = 20; p.node_size[] = p.node_size[] #hide
 f # hide
 
@@ -127,13 +127,13 @@ function (action::EdgeDragAction)(state, idx, event, axis)
     if state == true
         if action.src===action.dst===action.init===nothing
             action.init = event.data
-            action.src = p[:node_positions][][edge.src]
-            action.dst = p[:node_positions][][edge.dst]
+            action.src = p[:node_pos][][edge.src]
+            action.dst = p[:node_pos][][edge.dst]
         end
         offset = event.data - action.init
-        p[:node_positions][][edge.src] = action.src + offset
-        p[:node_positions][][edge.dst] = action.dst + offset
-        p[:node_positions][] = p[:node_positions][] # trigger change
+        p[:node_pos][][edge.src] = action.src + offset
+        p[:node_pos][][edge.dst] = action.dst + offset
+        p[:node_pos][] = p[:node_pos][] # trigger change
     elseif state == false
         action.src = action.dst = action.init =  nothing
     end
@@ -141,10 +141,10 @@ end
 edrag = EdgeDragHandler(EdgeDragAction())
 register_interaction!(ax, :edrag, edrag)
 
-p[:node_positions][][9] = nodepos[9] + Point2f0(0.9,1.0) #hide
-p[:node_positions][][10] = nodepos[10] + Point2f0(0.9,1.0) #hide
-p[:node_positions][] = p[:node_positions][] #hide
-pm = (p[:node_positions][][9] + p[:node_positions][][10])/2 #hide
+p[:node_pos][][9] = nodepos[9] + Point2f0(0.9,1.0) #hide
+p[:node_pos][][10] = nodepos[10] + Point2f0(0.9,1.0) #hide
+p[:node_pos][] = p[:node_pos][] #hide
+pm = (p[:node_pos][][9] + p[:node_pos][][10])/2 #hide
 set_cursor!(pm) #hide
 p.edge_width[][18] = 5.0; p.edge_width[] = p.edge_width[] #hide
 f # hide

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -193,7 +193,20 @@ f, ax, p = graphplot(g; layout=SquareGrid(cols=3), tangents, tfactor,
                      arrow_size=20, arrow_show=true, edge_color=[:red, :green, :blue],
                      elabels="Edge ".*repr.(1:ne(g)), elabels_distance=10)
 hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
-plot_controlpoints!(ax, p)
+plot_controlpoints!(ax, p) # show control points for demonstration
+f # hide
+
+#=
+## Edge waypoints
+It is possible to specify waypoints per edge which needs to be crossed. See the
+[Dependency Graph of a Package](@ref) example.
+The waypoints may or may not include the src/dst positions. The points will be
+connected using natural cubic splines.
+=#
+g = complete_graph(2)
+wp = Dict(1 => [(0.75, 0.5), (0.25, -0.5)])
+f, ax, p = graphplot(g; layout=SquareGrid(), waypoints=wp)
+plot_controlpoints!(ax, p) # show control points for demonstration
 f # hide
 
 #=

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -200,13 +200,43 @@ f # hide
 ## Edge waypoints
 It is possible to specify waypoints per edge which needs to be crossed. See the
 [Dependency Graph of a Package](@ref) example.
-The waypoints may or may not include the src/dst positions. The points will be
-connected using natural cubic splines.
+
+If the attribute `waypoint_radius` is `nothing` or `:spline` the waypoints will be crossed
+using natural cubic spline interpolation. If the supply a radius the waypoints won't be reached,
+instead they will be connected with straight lines which bend in the given radius around the
+waypoints.
 =#
-g = complete_graph(2)
-wp = Dict(1 => [(0.75, 0.5), (0.25, -0.5)])
-f, ax, p = graphplot(g; layout=SquareGrid(), waypoints=wp)
-plot_controlpoints!(ax, p) # show control points for demonstration
+set_theme!(resolution=(800, 800)) #hide
+g = SimpleGraph(8); add_edge!(g, 1, 2); add_edge!(g, 3, 4); add_edge!(g, 5, 6); add_edge!(g, 7, 8)
+
+waypoints = Dict(1 => [(.25,  0.25), (.75, -0.25)],
+                 2 => [(.25, -0.25), (.75, -0.75)],
+                 3 => [(.25, -0.75), (.75, -1.25)],
+                 4 => [(.25, -1.25), (.75, -1.75)])
+waypoint_radius = Dict(1 => nothing,
+                       2 => 0,
+                       3 => 0.05,
+                       4 => 0.15)
+
+f = Figure(); f[1,1] = ax = Axis(f)
+using Makie.Colors # hide
+for i in 3:4 #hide
+    poly!(ax, Circle(Point2f0(waypoints[i][1]), waypoint_radius[i]), color=RGBA(0.0,0.44705883,0.69803923,0.2)) #hide
+    poly!(ax, Circle(Point2f0(waypoints[i][2]), waypoint_radius[i]), color=RGBA(0.0,0.44705883,0.69803923,0.2)) #hide
+end #hide
+
+p = graphplot!(ax, g; layout=SquareGrid(cols=2, dy=-0.5),
+               waypoints, waypoint_radius,
+               nlabels=["","r = nothing (equals :spline)",
+                        "","r = 0 (straight lines)",
+                        "","r = 0.05 (in data space)",
+                        "","r = 0.1"],
+               nlabels_distance=30, nlabels_align=(:left,:center))
+
+for i in 1:4 #hide
+    scatter!(ax, waypoints[i], color=RGBA(0.0,0.44705883,0.69803923,1.0)) #hide
+end #hide
+xlims!(ax, (-0.1, 2.25)), hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
 f # hide
 
 #=

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -150,7 +150,7 @@ hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
 f # hide
 
 #=
-## Self Edges
+## Self edges
 
 A self edge in a graph will be displayed as a loop.
 
@@ -172,6 +172,28 @@ p.selfedge_direction = Point2f0(0.3, 1)
 p.selfedge_width = Any[Makie.automatic for i in 1:ne(g)]
 p.selfedge_width[][4] = 0.6*π; notify(p.selfedge_width)
 autolimits!(ax)
+f # hide
+
+#=
+## Curvy edges
+
+Curvy edges are possible using the low level interface of passing tangent
+vectors and a `tfactor`. The tangent vectors can be `nothing` (straight line) or
+two vectors per edge (one for src vertex, one for dst vertex). The `tfactor`
+scales the distance of the bezier control point relative to the distance of src
+and dst nodes. For real world usage see the [AST of a Julia function](@ref) example.
+=#
+using GraphMakie: plot_controlpoints!
+g = complete_graph(3)
+tangents = Dict(1 => ((1,1),(0,-1)),
+                2 => ((0,1),(0,-1)),
+                3 => ((0,-1),(1,0)))
+tfactor = [0.5, 0.75, (0.5, 0.25)]
+f, ax, p = graphplot(g; layout=SquareGrid(cols=3), tangents, tfactor,
+                     arrow_size=20, arrow_show=true, edge_color=[:red, :green, :blue],
+                     elabels="Edge ".*repr.(1:ne(g)), elabels_distance=10)
+hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
+plot_controlpoints!(ax, p)
 f # hide
 
 #=

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -84,7 +84,7 @@ f # hide
 
 # This is not very nice, lets change the offsets based on the `node_positions`
 
-offsets = 0.15 * (p[:node_positions][] .- p[:node_positions][][1])
+offsets = 0.15 * (p[:node_pos][] .- p[:node_pos][][1])
 offsets[1] = Point2f0(0, 0.3)
 p.nlabels_offset[] = offsets
 autolimits!(ax)

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -150,6 +150,31 @@ hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
 f # hide
 
 #=
+## Self Edges
+
+A self edge in a graph will be displayed as a loop.
+
+!!! note
+    Selfe edges are not possible in 3D plots yet.
+=#
+g = complete_graph(3)
+add_edge!(g, 1, 1)
+add_edge!(g, 2, 2)
+add_edge!(g, 3, 3)
+f, ax, p = graphplot(g)
+
+hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
+f # hide
+
+# It is possible to change the appearance using the `selfedge_` attributes:
+p.selfedge_size = Dict(1=>Makie.automatic, 4=>3.6, 6=>0.5) #idx as in edges(g)
+p.selfedge_direction = Point2f0(0.3, 1)
+p.selfedge_width = Any[Makie.automatic for i in 1:ne(g)]
+p.selfedge_width[][4] = 0.6*π; notify(p.selfedge_width)
+autolimits!(ax)
+f # hide
+
+#=
 ## Plot Graphs in 3D
 If the layout returns points in 3 dimensions, the plot will be in 3D. However this is a bit
 experimental. Feel free to file an issue if there are any problems.

--- a/docs/examples/syntaxtree.jl
+++ b/docs/examples/syntaxtree.jl
@@ -1,5 +1,5 @@
 #=
-# AST of a Julia function definition
+# AST of a Julia function
 
 In this example we are going to plot an abstract syntax tree of a Julia function using the
 Bucheim Layout from [`NetworkLayout.jl`](https://github.com/JuliaGraphs/NetworkLayout.jl).
@@ -72,7 +72,8 @@ nlabels_align = [(:left, :bottom) for v in vertices(g)]
 fig, ax, p = graphplot(g; layout=Buchheim(),
                        nlabels=repr.(labels),
                        nlabels_distance=5,
-                       nlabels_align)
+                       nlabels_align,
+                       tangents=((0,-1),(0,-1)))
 hidedecorations!(ax); hidespines!(ax)
 fig #hide
 

--- a/docs/examples/syntaxtree.jl
+++ b/docs/examples/syntaxtree.jl
@@ -83,8 +83,8 @@ for v in vertices(g)
     elseif isempty(outneighbors(g, v)) #leaf
         nlabels_align[v] = (:center,:top)
     else
-        self = p[:node_positions][][v]
-        parent = p[:node_positions][][inneighbors(g, v)[1]]
+        self = p[:node_pos][][v]
+        parent = p[:node_pos][][inneighbors(g, v)[1]]
         if self[1] < parent[1] # left branch
             nlabels_align[v] = (:right,:bottom)
         end

--- a/docs/examples/truss.jl
+++ b/docs/examples/truss.jl
@@ -161,7 +161,7 @@ p = graphplot!(ax, g;
                edge_color=[0.0 for i in 1:ne(g)],
                edge_attr=(colorrange=(fmin,fmax),
                           colormap=:diverging_bkr_55_10_c35_n256))
-hidespines!(ax); hidedecorations!(ax); p[:node_positions][]=to_pos(u0); ax.aspect = DataAspect()
+hidespines!(ax); hidedecorations!(ax); p[:node_pos][]=to_pos(u0); ax.aspect = DataAspect()
 limits!(ax, -0.1, pos0[end][1]+0.3, pos0[end][2]-0.5, 1.15)
 
 ## draw colorbar
@@ -172,7 +172,7 @@ fps = 30
 trange = range(0.0, sol.t[end], length=Int(T * fps))
 record(fig, "truss.mp4", trange; framerate=fps) do t
     title.text = @sprintf "Stress on truss (t = %.2f )" t
-    p[:node_positions][] = to_pos(sol(t))
+    p[:node_pos][] = to_pos(sol(t))
     load = get_load(sol(t), para)
     p.elabels = [@sprintf("%.0f", l) for l in load]
     p.edge_color[] = load

--- a/src/GraphMakie.jl
+++ b/src/GraphMakie.jl
@@ -10,5 +10,6 @@ import Makie: DocThemer, ATTRIBUTES, project, automatic
 include("beziercurves.jl")
 include("recipes.jl")
 include("interaction.jl")
+include("utils.jl")
 
 end

--- a/src/GraphMakie.jl
+++ b/src/GraphMakie.jl
@@ -7,6 +7,7 @@ using LinearAlgebra
 
 import Makie: DocThemer, ATTRIBUTES, project, automatic
 
+include("beziercurves.jl")
 include("recipes.jl")
 include("interaction.jl")
 

--- a/src/beziercurves.jl
+++ b/src/beziercurves.jl
@@ -226,17 +226,22 @@ end
 
 # same function as above but for just 2 points specificially
 function Path(P::Vararg{PT, 2}; tangents=nothing, tfactor=.5) where {PT<:AbstractPoint}
+    if tfactor isa NTuple{2, <:Number}
+        tf1, tf2 = tfactor
+    else
+        tf1 = tf2 = tfactor
+    end
+
     p1, p2 = P
     if tangents === nothing
         return Line(p1, p2)
     else
-        t1, t2 = normalize(tangents[1]), normalize(tangents[2])
-        dir = p2 - p1
-        d1 = tfactor * norm(dir ⋅ t1)
-        d2 = tfactor * norm(dir ⋅ t2)
+        t1 = normalize(Pointf0(tangents[1]))
+        t2 = normalize(Pointf0(tangents[2]))
+        len = norm(p2 - p1)
         return BezierPath([MoveTo(p1),
-                           CurveTo(PT(p1+d1*t1),
-                                   PT(p2-d2*t2),
+                           CurveTo(PT(p1+len*tf1*t1),
+                                   PT(p2-len*tf2*t2),
                                    p2)])
     end
 end

--- a/src/beziercurves.jl
+++ b/src/beziercurves.jl
@@ -1,5 +1,5 @@
-using Makie.GeometryBasics
-using Makie.GeometryBasics.StaticArrays
+using GeometryBasics
+using StaticArrays
 using LinearAlgebra: normalize, ⋅
 
 ####

--- a/src/beziercurves.jl
+++ b/src/beziercurves.jl
@@ -90,7 +90,7 @@ end
 
 Parametrize path `p` from `t ∈ [0, 1]`. Return postion at `t`.
 
-TODO: Points are necessarily evenly spaced!
+TODO: Points are not necessarily evenly spaced!
 """
 function interpolate(p::BezierPath{PT}, t) where PT
     @assert p.commands[begin] isa MoveTo

--- a/src/beziercurves.jl
+++ b/src/beziercurves.jl
@@ -26,6 +26,8 @@ struct CurveTo{PT} <: PathCommand{PT}
     p::PT
 end
 
+ptype(::Union{BezierPath{PT}, Type{BezierPath{PT}}}) where {PT} = PT
+
 
 ####
 #### Helper functions to work with bezier pathes

--- a/src/beziercurves.jl
+++ b/src/beziercurves.jl
@@ -1,0 +1,180 @@
+using Makie.GeometryBasics
+using Makie.GeometryBasics.StaticArrays
+using LinearAlgebra: normalize
+
+####
+#### Type definitions
+####
+
+abstract type PathCommand{PT<:AbstractPoint} end
+
+struct BezierPath{PT}
+    commands::Vector{PathCommand{PT}}
+end
+
+struct MoveTo{PT} <: PathCommand{PT}
+    p::PT
+end
+
+struct LineTo{PT} <: PathCommand{PT}
+    p::PT
+end
+
+struct CurveTo{PT} <: PathCommand{PT}
+    c1::PT
+    c2::PT
+    p::PT
+end
+
+
+####
+#### Helper functions to work with bezier pathes
+####
+
+"""
+    interpolate(c::PathCommand, p0, t)
+
+Returns positions along the path `c` starting from `p0` in range `t ∈ [0, 1]`.
+"""
+interpolate(c::LineTo{PT}, p0, t) where {PT} = p0 + t*(c.p - p0) |> PT
+function interpolate(c::CurveTo{PT}, p0, t) where {PT}
+    p1, p2, p3 = c.c1, c.c2, c.p
+    (1 - t)^3 * p0 + 3(t - 2t^2 + t^3) * p1 + 3(t^2 -t^3) * p2 + t^3 * p3 |> PT
+end
+
+"""
+    tangent(c::PathCommand, p0, t)
+
+Returns tanget vector along the path `c` starting from `p0` in range `t ∈ [0, 1]`.
+"""
+tangent(c::LineTo, p0, _) = normalize(c.p - p0)
+function tangent(c::CurveTo{PT}, p0, t) where PT
+    p1, p2, p3 = c.c1, c.c2, c.p
+    normalize(-3(1 - t)^2 * p0 + 3(1 - 4t + 3t^2) * p1 + 3(2t -3t^2) * p2 + 3t^2 * p3) |> PT
+end
+
+"""
+    discretize!(v::Vector{AbstractPint}, c::PathCommand)
+
+Append interpolated points of path `c` to pos vector `v`
+"""
+discretize!(v::Vector{<:AbstractPoint}, c::Union{MoveTo, LineTo}) = push!(v, c.p)
+function discretize!(v::Vector{<:AbstractPoint}, c::CurveTo)
+    N0 = length(v)
+    p0 = v[end]
+    N = 100
+    resize!(v, N0 + N)
+    dt = 1.0/N
+    for (i, t) in enumerate(dt:dt:1.0)
+        v[N0 + i] = interpolate(c, p0, t)
+    end
+end
+
+"""
+    discretize(path::BezierPath)
+
+Return vector of points which represent the given `path`.
+"""
+function discretize(path::BezierPath{T}) where {T}
+    v = Vector{T}()
+    for c in path.commands
+        discretize!(v, c)
+    end
+    return v
+end
+
+"""
+    interpolate(p::BezierPath, t)
+
+Parametrize path `p` from `t ∈ [0, 1]`. Return postion at `t`.
+
+TODO: Points are necessarily evenly spaced!
+"""
+function interpolate(p::BezierPath{PT}, t) where PT
+    @assert p.commands[begin] isa MoveTo
+    N = length(p.commands) - 1
+
+    tn = N*t
+    seg = min(floor(Int, tn), N-1)
+    tseg = tn - seg
+
+    p0 = p.commands[seg+1].p
+    return interpolate(p.commands[seg+2], p0, tseg)
+end
+
+"""
+    tangent(p::BezierPath, t)
+
+Parametrize path `p` from `t ∈ [0, 1]`. Return tangent at `t`.
+"""
+function tangent(p::BezierPath, t)
+    @assert p.commands[begin] isa MoveTo
+    N = length(p.commands) - 1
+
+    tn = N*t
+    seg = min(floor(Int, tn), N-1)
+    tseg = tn - seg
+
+    p0 = p.commands[seg+1].p
+    return tangent(p.commands[seg+2], p0, tseg)
+end
+
+
+####
+#### Special constructors to create bezier pathes
+####
+
+"""
+    BezierPath(P::Vararg{PT, N}) where {PT<:AbstractPoint, N}
+
+Create a bezier path by natural cubic spline interpolation of the points `P`.
+"""
+function BezierPath(P::Vararg{PT, N}) where {PT<:AbstractPoint, N}
+    if length(P) == 2
+        return BezierPath([MoveTo(P[1]), LineTo(P[2])])
+    end
+
+    # cubic_spline will work for each dimension separatly
+    pxyz = cubic_spline(map(p -> p[1], P)) # get first dimension
+    for i in 2:length(PT) # append all other dims
+        pxyz = hcat(pxyz, cubic_spline(map(p -> p[i], P)))
+    end
+
+    # create waypoints from waypoints in separat dementions
+    WP = SVector{length(P)-1}(PT(p) for p in eachrow(pxyz))
+
+    commands = Vector{PathCommand{PT}}(undef, N)
+    commands[1] = MoveTo(P[1])
+    for i in 2:(N-1)
+        commands[i] = CurveTo(WP[i-1],
+                              2*P[i] - WP[i],
+                              P[i])
+    end
+    commands[N] = CurveTo(WP[N-1],
+                          (P[N] + WP[N-1])/2,
+                          P[N])
+    BezierPath(commands)
+end
+
+function cubic_spline(p)
+    N = length(p) - 1
+
+    M = SMatrix{N,N}(if i==j # diagonal
+                         if i==1; 2; elseif i==N; 7; else 4 end
+                     elseif i==j+1 # lower
+                         if i==N; 2; else 1 end
+                     elseif i==j-1 # upper
+                         1
+                     else
+                         0
+                     end for i in 1:N, j in 1:N)
+
+    b = SVector{N}(if i == 1
+                       p[i] + 2p[i+1]
+                   elseif i == N
+                       8p[i] + p[i+1]
+                   else
+                       4p[i] + 2p[i+1]
+                   end for i in 1:N)
+    return M \ b
+end

--- a/src/interaction.jl
+++ b/src/interaction.jl
@@ -253,8 +253,8 @@ julia> g = wheel_digraph(10)
 julia> f, ax, p = graphplot(g, node_size=20)
 julia> deregister_interaction!(ax, :rectanglezoom)
 julia> function action(state, idx, event, axis)
-           p[:node_positions][][idx] = event.data
-           p[:node_positions][] = p[:node_positions][]
+           p[:node_pos][][idx] = event.data
+           p[:node_pos][] = p[:node_positions][]
        end
 julia> register_interaction!(ax, :nodedrag, NodeDragHandler(action))
 ```
@@ -277,8 +277,8 @@ julia> register_interaction!(ax, :nodedrag, NodeDrag(p))
 """
 function NodeDrag(p)
     action = (state, idx, event, _) -> begin
-        p[:node_positions][][idx] = event.data
-        p[:node_positions][] = p[:node_positions][]
+        p[:node_pos][][idx] = event.data
+        p[:node_pos][] = p[:node_positions][]
     end
     return NodeDragHandler(action)
 end
@@ -330,13 +330,13 @@ function (action::EdgeDragAction)(state, idx, event, _)
     if state == true
         if action.src === action.dst === action.init === nothing
             action.init = event.data
-            action.src = action.p[:node_positions][][edge.src]
-            action.dst = action.p[:node_positions][][edge.dst]
+            action.src = action.p[:node_pos][][edge.src]
+            action.dst = action.p[:node_pos][][edge.dst]
         end
         offset = event.data - action.init
-        action.p[:node_positions][][edge.src] = action.src + offset
-        action.p[:node_positions][][edge.dst] = action.dst + offset
-        action.p[:node_positions][] = action.p[:node_positions][] # trigger change
+        action.p[:node_pos][][edge.src] = action.src + offset
+        action.p[:node_pos][][edge.dst] = action.dst + offset
+        action.p[:node_pos][] = action.p[:node_pos][] # trigger change
     elseif state == false
         action.src = action.dst = action.init = nothing
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -27,7 +27,7 @@ underlying graph and therefore changing the number of Edges/Nodes.
 - `layout=Spring()`: function `AbstractGraph->Vector{Point}` determines the base layout
 - `node_color=scatter_theme.color`
 - `node_size=scatter_theme.markersize`
-- `node_marker=scatter_theme.marker`k
+- `node_marker=scatter_theme.marker`
 - `node_attr=(;)`: List of kw arguments which gets passed to the `scatter` command
 - `edge_color=lineseg_theme.color`: Pass a vector with 2 colors per edge to get
   color gradients.
@@ -332,6 +332,7 @@ end
 function selfedge_path(g, pos::AbstractVector{Point3f0}, v)
     error("Self edges in 3D not yet supported")
 end
+
 
 """
     beziersegments(paths::Vector{BezierPath})

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -7,7 +7,7 @@ export GraphPlot, graphplot, graphplot!
 
 Creates a plot of the network `graph`. Consists of multiple steps:
 - Layout the nodes: see `layout` attribute. The node position is accesible from outside
-  the plot object `p` as an observable using `p[:node_positions]`.
+  the plot object `p` as an observable using `p[:node_pos]`.
 - plot edges as `linesegments`-plot
 - if `arrows_show` plot arrowheads as `scatter`-plot
 - plot nodes as `scatter`-plot
@@ -119,9 +119,9 @@ function Makie.plot!(gp::GraphPlot)
 
     # create initial vertex positions, will be updated on changes to graph or layout
     # make node_position-Observable available as named attribute from the outside
-    gp[:node_positions] = @lift [toF32(Point(p)) for p in ($(gp.layout))($graph)]
+    gp[:node_pos] = @lift [toF32(Point(p)) for p in ($(gp.layout))($graph)]
 
-    node_pos = gp[:node_positions]
+    node_pos = gp[:node_pos]
 
     # create array of pathes triggered by node_pos changes
     # in case of a graph change the node_position will change anyway

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -127,7 +127,7 @@ function Makie.plot!(gp::GraphPlot)
 
     # create initial vertex positions, will be updated on changes to graph or layout
     # make node_position-Observable available as named attribute from the outside
-    gp[:node_pos] = @lift [toF32(Point(p)) for p in ($(gp.layout))($graph)]
+    gp[:node_pos] = @lift [Pointf0(p) for p in ($(gp.layout))($graph)]
 
     node_pos = gp[:node_pos]
 
@@ -272,8 +272,13 @@ function Makie.plot!(gp::GraphPlot)
     return gp
 end
 
-toF32(p::Point{2, T}) where T = Point2f0(p)
-toF32(p::Point{3, T}) where T = Point3f0(p)
+"""
+    Pointf0(p::Point{N, T})
+
+Convert Point{N, T} or NTuple{N, T} to Point{N, Float32}.
+"""
+Pointf0(p::Union{Point{N,T}, NTuple{N,T}}) where {N,T} = Point{N, Float32}(p)
+Pointf0(p::Vararg{T,N}) where {N,T} = Point{N, Float32}(p)
 
 function align_to_dir(align)
     halign, valign = align

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1,3 +1,4 @@
+using LinearAlgebra: normalize, ⋅, norm
 export GraphPlot, graphplot, graphplot!
 
 """
@@ -118,7 +119,7 @@ function Makie.plot!(gp::GraphPlot)
 
     # create initial vertex positions, will be updated on changes to graph or layout
     # make node_position-Observable available as named attribute from the outside
-    gp[:node_positions] = @lift [Point(p) for p in ($(gp.layout))($graph)]
+    gp[:node_positions] = @lift [toF32(Point(p)) for p in ($(gp.layout))($graph)]
 
     node_pos = gp[:node_positions]
 
@@ -261,6 +262,9 @@ function Makie.plot!(gp::GraphPlot)
 
     return gp
 end
+
+toF32(p::Point{2, T}) where T = Point2f0(p)
+toF32(p::Point{3, T}) where T = Point3f0(p)
 
 function align_to_dir(align)
     halign, valign = align

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -350,7 +350,7 @@ function selfedge_path(g, pos::AbstractVector{<:Point2}, v, size, direction, wid
     # angle and maximum width of loop
     γ, Δ = 0.0, 0.0
 
-    if direction === automatic
+    if direction === automatic && !isempty(ndirs)
         angles = SVector{length(ndirs)}(atan(p[2], p[1]) for p in ndirs)
         angles = sort(angles)
 
@@ -365,6 +365,9 @@ function selfedge_path(g, pos::AbstractVector{<:Point2}, v, size, direction, wid
 
         # set width of selfloop
         Δ = min(.7*Δ, π/2)
+    elseif direction === automatic && isempty(ndirs)
+        γ = π/2
+        Δ = π/2
     else
         @assert direction isa Point2 "Direction of selfedge should be 2 dim vector ($direction)"
         γ = atan(direction[2], direction[1])
@@ -375,8 +378,11 @@ function selfedge_path(g, pos::AbstractVector{<:Point2}, v, size, direction, wid
         Δ = width
     end
 
-    # the size (max dis. to v) of loop
-    size = size===automatic ? minimum(norm.(ndirs)) * 0.5 : size
+    # the size (max distance to v) of loop
+    # if there are no neighbors set to 0.5. Else half dist to nearest neighbor
+    if size === automatic
+        size = isempty(ndirs) ? 0.5 : minimum(norm.(ndirs)) * 0.5
+    end
 
     # the actual length of the tagent vectors, magic number from `CurveTo`
     l = Float32( size/(cos(Δ/2) * 2*0.375) )

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -75,6 +75,16 @@ the edge.
 - `selfedge_size=Makie.automatic()`: Size of self-edge-loop (dict/vector possible).
 - `selfedge_direction=Makie.automatic()`: Direction of self-edge-loop as `Point2` (dict/vector possible).
 - `selfedge_width=Makie.automatic()`: Opening of selfloop in rad (dict/vector possible).
+- `tangents=nothing`:
+
+    Specify a pair of tangent vectors per edge (for src and dst). If `nothing`
+    (or edge idx not in dict) draw a straight line.
+
+- `tfactor=0.6`:
+
+    Factor is used to calculate the bezier waypoints from the (normalized) tangets.
+    Higher factor means bigger radius. Can be tuple per edge to specify different
+    factor for src and dst.
 
 """
 @recipe(GraphPlot, graph) do scene
@@ -122,6 +132,8 @@ the edge.
         selfedge_size = automatic,
         selfedge_direction = automatic,
         selfedge_width = automatic,
+        tangents=nothing,
+        tfactor=0.6
     )
 end
 
@@ -287,7 +299,9 @@ function find_edge_paths(g, attr, pos::AbstractVector{PT}) where {PT}
             width = getattr(attr.selfedge_width, i)
             paths[i] = selfedge_path(g, pos, e.src, size, direction, width)
         else
-            paths[i] = Path(pos[e.src], pos[e.dst])
+            tangents = getattr(attr.tangents, i)
+            tfactor = getattr(attr.tfactor, i)
+            paths[i] = Path(pos[e.src], pos[e.dst]; tangents, tfactor)
         end
     end
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -272,39 +272,10 @@ function Makie.plot!(gp::GraphPlot)
     return gp
 end
 
-"""
-    Pointf0(p::Point{N, T})
-
-Convert Point{N, T} or NTuple{N, T} to Point{N, Float32}.
-"""
-Pointf0(p::Union{Point{N,T}, NTuple{N,T}}) where {N,T} = Point{N, Float32}(p)
-Pointf0(p::Vararg{T,N}) where {N,T} = Point{N, Float32}(p)
 
 """
-    align_to_dir(align::Tuple{Symbol, Symbol})
 
-Given a tuple of alignment (i.e. `(:left, :bottom)`) return a normalized
-2d vector which points in the direction of the offset.
 """
-function align_to_dir(align::Tuple{Symbol, Symbol})
-    halign, valign = align
-
-    x = 0.0
-    if halign === :left
-        x = 1.0
-    elseif halign === :right
-        x = -1.0
-    end
-
-    y = 0.0
-    if valign === :top
-        y = -1.0
-    elseif valign === :bottom
-        y = 1.0
-    end
-    norm = x==y==0.0 ? 1 : sqrt(x^2 + y^2)
-    return Point2f0(x/norm, y/norm)
-end
 
 function find_edge_paths(g, attr, pos::AbstractVector{PT}) where {PT}
     paths = Vector{BezierPath{PT}}(undef, ne(g))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,7 +2,7 @@ export get_edge_plot, get_arrow_plot, get_node_plot, get_nlabel_plot, get_elabel
 
 function get_edge_plot(gp::GraphPlot)
     p = gp.plots[1]
-    @assert p isa BezierSegments
+    @assert p isa EdgePlot
     return p
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -40,19 +40,19 @@ function _get_label_plot(gp::GraphPlot, labels)
 end
 
 """
-    getattr(o::Observable, idx)
+    getattr(o::Observable, idx, default=nothing)
 
 If observable wraps an AbstractVector or AbstractDict return
-the value at idx. If dict has no key idx rerturn nothing.
+the value at idx. If dict has no key idx rerturn default.
 Else return the one and only element.
 """
-function getattr(o::Observable, idx)
+function getattr(o::Observable, idx, default=nothing)
     if o[] isa AbstractVector && !isa(o[], Point)
         return o[][idx]
     elseif o[] isa AbstractDict
-        return get(o[], idx, nothing)
+        return get(o[], idx, default)
     else
-        return o[]
+        return o[] === nothing ? default : o[]
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,13 @@
 export get_edge_plot, get_arrow_plot, get_node_plot, get_nlabel_plot, get_elabel_plot
 
+"Get the `EdgePlot` subplot from a `GraphPlot`."
 function get_edge_plot(gp::GraphPlot)
     p = gp.plots[1]
     @assert p isa EdgePlot
     return p
 end
 
+"Get the scatter plot of the arrow heads from a `GraphPlot`."
 function get_arrow_plot(gp::GraphPlot)
     p = gp.plots[2]
     @assert p isa Scatter
@@ -13,6 +15,7 @@ function get_arrow_plot(gp::GraphPlot)
     return p
 end
 
+"Get the scatter plot of the nodes from a `GraphPlot`."
 function get_node_plot(gp::GraphPlot)
     p = gp.plots[3]
     @assert p isa Scatter
@@ -20,7 +23,9 @@ function get_node_plot(gp::GraphPlot)
     return p
 end
 
+"Get the text plot of the node labels from a `GraphPlot`."
 get_nlabel_plot(gp::GraphPlot) = _get_label_plot(gp, gp.nlabels[])
+"Get the text plot of the edge labels from a `GraphPlot`."
 get_elabel_plot(gp::GraphPlot) = _get_label_plot(gp, gp.elabels[])
 
 function _get_label_plot(gp::GraphPlot, labels)
@@ -46,4 +51,38 @@ function getattr(o::Observable, idx)
     else
         return o[]
     end
+end
+
+"""
+    Pointf0(p::Point{N, T})
+
+Convert Point{N, T} or NTuple{N, T} to Point{N, Float32}.
+"""
+Pointf0(p::Union{Point{N,T}, NTuple{N,T}}) where {N,T} = Point{N, Float32}(p)
+Pointf0(p::Vararg{T,N}) where {N,T} = Point{N, Float32}(p)
+
+"""
+    align_to_dir(align::Tuple{Symbol, Symbol})
+
+Given a tuple of alignment (i.e. `(:left, :bottom)`) return a normalized
+2d vector which points in the direction of the offset.
+"""
+function align_to_dir(align::Tuple{Symbol, Symbol})
+    halign, valign = align
+
+    x = 0.0
+    if halign === :left
+        x = 1.0
+    elseif halign === :right
+        x = -1.0
+    end
+
+    y = 0.0
+    if valign === :top
+        y = -1.0
+    elseif valign === :bottom
+        y = 1.0
+    end
+    norm = x==y==0.0 ? 1 : sqrt(x^2 + y^2)
+    return Point2f0(x/norm, y/norm)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,6 +90,13 @@ function align_to_dir(align::Tuple{Symbol, Symbol})
     return Point2f0(x/norm, y/norm)
 end
 
+"""
+    plot_controlpoints!(ax::Axis, gp::GraphPlot)
+    plot_controlpoints!(ax::Axis, path::BezierPath)
+
+Add all the bezier controlpoints of graph plot or a single
+path to the axis `ax`.
+"""
 function plot_controlpoints!(ax::Axis, gp::GraphPlot)
     ep = get_edge_plot(gp)
     ep.plots[1] isa BezierSegments || return
@@ -99,12 +106,16 @@ function plot_controlpoints!(ax::Axis, gp::GraphPlot)
     for (i, p) in enumerate(paths)
         p isa Line && continue
         color = getattr(gp.edge_color, i)
-        for (j, c) in enumerate(p.commands)
-            if c isa CurveTo
-                segs = [p.commands[j-1].p, c.c1, c.p, c.c2]
-                linesegments!(ax, segs; color, linestyle=:dot)
-                scatter!(ax, [c.c1, c.c2]; color)
-            end
+        plot_controlpoints!(ax, p; color)
+    end
+end
+
+function plot_controlpoints!(ax::Axis, p::BezierPath; color=:black)
+    for (j, c) in enumerate(p.commands)
+        if c isa CurveTo
+            segs = [p.commands[j-1].p, c.c1, c.p, c.c2]
+            linesegments!(ax, segs; color, linestyle=:dot)
+            scatter!(ax, [c.c1, c.c2]; color)
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,35 @@
+export get_edge_plot, get_arrow_plot, get_node_plot, get_nlabel_plot, get_elabel_plot
+
+function get_edge_plot(gp::GraphPlot)
+    p = gp.plots[1]
+    @assert p isa BezierSegments
+    return p
+end
+
+function get_arrow_plot(gp::GraphPlot)
+    p = gp.plots[2]
+    @assert p isa Scatter
+    @assert p.marker[] == '➤'
+    return p
+end
+
+function get_node_plot(gp::GraphPlot)
+    p = gp.plots[3]
+    @assert p isa Scatter
+    @assert p[1][] == gp[:node_pos][]
+    return p
+end
+
+get_nlabel_plot(gp::GraphPlot) = _get_label_plot(gp, gp.nlabels[])
+get_elabel_plot(gp::GraphPlot) = _get_label_plot(gp, gp.elabels[])
+
+function _get_label_plot(gp::GraphPlot, labels)
+    ps = filter(p -> p isa Makie.Text && p[1][] == labels, gp.plots)
+    if isempty(ps)
+        return nothing
+    elseif length(ps) == 1
+        return ps[1]
+    else
+        error("Could not determine plot $ps")
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,3 +33,17 @@ function _get_label_plot(gp::GraphPlot, labels)
         error("Could not determine plot $ps")
     end
 end
+
+"""
+    getattr(o::Observable, idx)
+
+If observable wraps an AbstractVector or AbstractDict return
+the value at idx. Else return the one and only element.
+"""
+function getattr(o::Observable, idx)
+    if o[] isa AbstractVector && !isa(o[], Point) || o[] isa AbstractDict
+        return o[][idx]
+    else
+        return o[]
+    end
+end

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -134,7 +134,6 @@ end
 end
 
 @testset "selfloop test" begin
-    using CairoMakie
     using LightGraphs, GraphMakie
     g = star_graph(10)
     add_edge!(g, 1, 1)

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -103,6 +103,27 @@ end
     path = Path(p1, p2; tangents=(t1, t2))
     lines(discretize(path))
     scatter!(waypoints(path))
+
+    p1 = Point2f0(0,0)
+    p2 = Point2f0(1,0)
+    midp = Point2f0[]
+    path = Path(p1, midp..., p2)
+    lines(discretize(path))
+end
+
+@testset "straight lines with radi" begin
+    using GraphMakie: plot_controlpoints!
+    p1 = Point2f0(0,0)
+    p2 = Point2f0(1,-.5)
+    p3 = Point2f0(2,.5)
+    p4 = Point2f0(3,0)
+    path = Path(0.5, p1, p2, p3, p4)
+    fig, ax, p = lines(discretize(path))
+    plot_controlpoints!(ax, path)
+    scatter!(ax, [p1,p2,p3,p4])
+
+    path = Path(0.0, p1, p2, p3, p4)
+    fig, ax, p = lines(discretize(path))
 end
 
 @testset "test beziersegments recipe" begin

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -25,11 +25,11 @@ using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, 
     arrows!(pos, tan; lengthscale=0.1)
 
     path = BezierPath([
-        MoveTo(Point2f0(0,0)),
-        LineTo(Point2f0(1,0)),
-        LineTo(Point2f0(1,1)),
-        LineTo(Point2f0(0,1)),
-        LineTo(Point2f0(0,0)),
+        MoveTo(Point2f0(0,0,0)),
+        LineTo(Point2f0(1,0,0)),
+        LineTo(Point2f0(1,1,1)),
+        LineTo(Point2f0(0,1,1)),
+        LineTo(Point2f0(0,0,1)),
                 ])
     ts = 0:0.1:1.0
     pos = map(t->interpolate(path,t), ts)

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -25,12 +25,11 @@ using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, 
     arrows!(pos, tan; lengthscale=0.1)
 
     path = BezierPath([
-        MoveTo(Point2f0(0,0,0)),
-        LineTo(Point2f0(1,0,0)),
-        LineTo(Point2f0(1,1,1)),
-        LineTo(Point2f0(0,1,1)),
-        LineTo(Point2f0(0,0,1)),
-                ])
+        MoveTo(Point3f0(0,0,0)),
+        LineTo(Point3f0(1,0,0)),
+        LineTo(Point3f0(1,1,1)),
+        LineTo(Point3f0(0,1,1)),
+        LineTo(Point3f0(0,0,1))])
     ts = 0:0.1:1.0
     pos = map(t->interpolate(path,t), ts)
     tan = map(t->tangent(path,t), ts)
@@ -113,4 +112,18 @@ end
     paths = [BezierPath(rand(Point2f0, 4)...) for _ in 1:4]
     fig, ax, p = beziersegments(paths; linewidth=[2,4,6,8], color=[1,2,3,4])
     p.attributes
+end
+
+@testset "selfloop test" begin
+    using CairoMakie
+    using LightGraphs, GraphMakie
+    g = star_graph(10)
+    add_edge!(g, 1, 1)
+    add_edge!(g, 2, 2)
+    fig, ax, p = graphplot(g)
+    ax.aspect = DataAspect()
+
+    g = star_graph(10)
+    add_edge!(g, 1, 1)
+    @test_throws ErrorException graphplot(g; layout=_->rand(Point3f0, 10))
 end

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -1,6 +1,6 @@
 using Test
 using GraphMakie
-using GraphMakie.Makie.GeometryBasics
+using GeometryBasics
 
 using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, tangent, waypoints, Path, Line
 

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -2,7 +2,7 @@ using Test
 using GraphMakie
 using GraphMakie.Makie.GeometryBasics
 
-using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, tangent, waypoints
+using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, tangent, waypoints, Path, Line
 
 @testset "interpolation and tangets" begin
     path = BezierPath([
@@ -38,37 +38,35 @@ using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, 
 end
 
 @testset "natural spline constructor" begin
-    path = BezierPath(Point2f0(0.0,0.0), Point2f0(0.0,1.0))
-    @test length(path.commands) == 2
-    @test path.commands[1] isa MoveTo
-    @test path.commands[2] isa LineTo
+    path = Path(Point2f0(0.0,0.0), Point2f0(0.0,1.0))
+    @test path isa GraphMakie.Line
 
-    path = BezierPath(Point2f0(0.0,0.0),
-                      Point2f0(0.0,1.0),
-                      Point2f0(1.0,1.0))
+    path = Path(Point2f0(0.0,0.0),
+                Point2f0(0.0,1.0),
+                Point2f0(1.0,1.0))
     lines(discretize(path))
     scatter!(waypoints(path))
 
-    path = BezierPath(Point2f0(0.0,0.0),
-                      Point2f0(-0.5,1.0),
-                      Point2f0(0.5,1.0),
-                      Point2f0(0.0,0.0))
+    path = Path(Point2f0(0.0,0.0),
+                Point2f0(-0.5,1.0),
+                Point2f0(0.5,1.0),
+                Point2f0(0.0,0.0))
     lines(discretize(path))
     scatter!(waypoints(path))
 
-    path = BezierPath(Point2f0(0.0,0.0),
-                      Point2f0(-0.5,1.0),
-                      Point2f0(1.5,1.0),
-                      Point2f0(2.0,0.0))
+    path = Path(Point2f0(0.0,0.0),
+                Point2f0(-0.5,1.0),
+                Point2f0(1.5,1.0),
+                Point2f0(2.0,0.0))
     lines(discretize(path))
     scatter!(waypoints(path))
 
-    path = BezierPath(Point2f0(0.0,0.0),
-                      Point2f0(-0.5,1.0),
-                      Point2f0(1.5,1.0),
-                      Point2f0(2.0,0.0);
-                      tangents=(Point2f0(-1,0),
-                                Point2f0(-1,0)))
+    path = Path(Point2f0(0.0,0.0),
+                Point2f0(-0.5,1.0),
+                Point2f0(1.5,1.0),
+                Point2f0(2.0,0.0);
+                tangents=(Point2f0(-1,0),
+                          Point2f0(-1,0)))
     lines(discretize(path), linewidth=10)
     scatter!(waypoints(path))
 end
@@ -78,7 +76,7 @@ end
     t1 = Point2f0(0,1)
     p2 = Point2f0(1,1)
     t2 = Point2f0(0,1)
-    path = BezierPath(p1, p2; tangents=(t1, t2))
+    path = Path(p1, p2; tangents=(t1, t2))
     lines(discretize(path))
     scatter!(waypoints(path))
 
@@ -86,7 +84,7 @@ end
     t1 = Point2f0(1,0)*10
     p2 = Point2f0(1,1)
     t2 = Point2f0(0,1)*5
-    path = BezierPath(p1, p2; tangents=(t1, t2))
+    path = Path(p1, p2; tangents=(t1, t2))
     lines(discretize(path))
     scatter!(waypoints(path))
 
@@ -94,7 +92,7 @@ end
     t1 = Point2f0(-1,0)
     p2 = Point2f0(1,1)
     t2 = Point2f0(0,1)
-    path = BezierPath(p1, p2; tangents=(t1, t2))
+    path = Path(p1, p2; tangents=(t1, t2))
     lines(discretize(path))
     scatter!(waypoints(path))
 
@@ -102,14 +100,14 @@ end
     t1 = Point2f0(-.5,.5)
     p2 = Point2f0(0,0)
     t2 = Point2f0(-.5,-.5)
-    path = BezierPath(p1, p2; tangents=(t1, t2))
+    path = Path(p1, p2; tangents=(t1, t2))
     lines(discretize(path))
     scatter!(waypoints(path))
 end
 
 @testset "test beziersegments recipe" begin
     using GraphMakie: beziersegments
-    paths = [BezierPath(rand(Point2f0, 4)...) for _ in 1:4]
+    paths = [Path(rand(Point2f0, 4)...) for _ in 1:4]
     fig, ax, p = beziersegments(paths; linewidth=[2,4,6,8], color=[1,2,3,4])
     p.attributes
 end

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -23,6 +23,19 @@ using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, 
 
     scatter!(pos)
     arrows!(pos, tan; lengthscale=0.1)
+
+    path = BezierPath([
+        MoveTo(Point2f0(0,0)),
+        LineTo(Point2f0(1,0)),
+        LineTo(Point2f0(1,1)),
+        LineTo(Point2f0(0,1)),
+        LineTo(Point2f0(0,0)),
+                ])
+    ts = 0:0.1:1.0
+    pos = map(t->interpolate(path,t), ts)
+    tan = map(t->tangent(path,t), ts)
+    fig, ax, p = scatter(pos)
+    arrows!(pos, tan; lengthscale=0.1)
 end
 
 @testset "natural spline constructor" begin
@@ -57,7 +70,7 @@ end
                       Point2f0(2.0,0.0);
                       tangents=(Point2f0(-1,0),
                                 Point2f0(-1,0)))
-    lines(discretize(path))
+    lines(discretize(path), linewidth=10)
     scatter!(waypoints(path))
 end
 
@@ -93,4 +106,11 @@ end
     path = BezierPath(p1, p2; tangents=(t1, t2))
     lines(discretize(path))
     scatter!(waypoints(path))
+end
+
+@testset "test beziersegments recipe" begin
+    using GraphMakie: beziersegments
+    paths = [BezierPath(rand(Point2f0, 4)...) for _ in 1:4]
+    fig, ax, p = beziersegments(paths; linewidth=[2,4,6,8], color=[1,2,3,4])
+    p.attributes
 end

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -1,10 +1,8 @@
 using Test
 using GraphMakie
 using GraphMakie.Makie.GeometryBasics
-using GLMakie
 
-using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, tangent
-
+using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, tangent, waypoints
 
 @testset "interpolation and tangets" begin
     path = BezierPath([
@@ -35,12 +33,64 @@ end
 
     path = BezierPath(Point2f0(0.0,0.0),
                       Point2f0(0.0,1.0),
-                      Point2f0(0.2,1.0),
                       Point2f0(1.0,1.0))
     lines(discretize(path))
+    scatter!(waypoints(path))
 
     path = BezierPath(Point2f0(0.0,0.0),
-                      Point2f0(0.0,1.0),
+                      Point2f0(-0.5,1.0),
+                      Point2f0(0.5,1.0),
                       Point2f0(0.0,0.0))
+    lines(discretize(path))
+    scatter!(waypoints(path))
 
+    path = BezierPath(Point2f0(0.0,0.0),
+                      Point2f0(-0.5,1.0),
+                      Point2f0(1.5,1.0),
+                      Point2f0(2.0,0.0))
+    lines(discretize(path))
+    scatter!(waypoints(path))
+
+    path = BezierPath(Point2f0(0.0,0.0),
+                      Point2f0(-0.5,1.0),
+                      Point2f0(1.5,1.0),
+                      Point2f0(2.0,0.0);
+                      tangents=(Point2f0(-1,0),
+                                Point2f0(-1,0)))
+    lines(discretize(path))
+    scatter!(waypoints(path))
+end
+
+@testset "two points and tangets" begin
+    p1 = Point2f0(0,0)
+    t1 = Point2f0(0,1)
+    p2 = Point2f0(1,1)
+    t2 = Point2f0(0,1)
+    path = BezierPath(p1, p2; tangents=(t1, t2))
+    lines(discretize(path))
+    scatter!(waypoints(path))
+
+    p1 = Point2f0(0,0)
+    t1 = Point2f0(1,0)*10
+    p2 = Point2f0(1,1)
+    t2 = Point2f0(0,1)*5
+    path = BezierPath(p1, p2; tangents=(t1, t2))
+    lines(discretize(path))
+    scatter!(waypoints(path))
+
+    p1 = Point2f0(0,0)
+    t1 = Point2f0(-1,0)
+    p2 = Point2f0(1,1)
+    t2 = Point2f0(0,1)
+    path = BezierPath(p1, p2; tangents=(t1, t2))
+    lines(discretize(path))
+    scatter!(waypoints(path))
+
+    p1 = Point2f0(0,0)
+    t1 = Point2f0(-.5,.5)
+    p2 = Point2f0(0,0)
+    t2 = Point2f0(-.5,-.5)
+    path = BezierPath(p1, p2; tangents=(t1, t2))
+    lines(discretize(path))
+    scatter!(waypoints(path))
 end

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -1,0 +1,46 @@
+using Test
+using GraphMakie
+using GraphMakie.Makie.GeometryBasics
+using GLMakie
+
+using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, tangent
+
+
+@testset "interpolation and tangets" begin
+    path = BezierPath([
+        MoveTo(Point2f0(0,0)),
+        LineTo(Point2f0(0.5,0.5)),
+        CurveTo(Point2f0(1,0),
+                Point2f0(1,0),
+                Point2f0(1,1)),
+        CurveTo(Point2f0(1,2),
+                Point2f0(0,2),
+                Point2f0(0,1))])
+
+    lines(discretize(path))
+
+    ts = 0:0.1:1.0
+    pos = map(t->interpolate(path,t), ts)
+    tan = map(t->tangent(path,t), ts)
+
+    scatter!(pos)
+    arrows!(pos, tan; lengthscale=0.1)
+end
+
+@testset "natural spline constructor" begin
+    path = BezierPath(Point2f0(0.0,0.0), Point2f0(0.0,1.0))
+    @test length(path.commands) == 2
+    @test path.commands[1] isa MoveTo
+    @test path.commands[2] isa LineTo
+
+    path = BezierPath(Point2f0(0.0,0.0),
+                      Point2f0(0.0,1.0),
+                      Point2f0(0.2,1.0),
+                      Point2f0(1.0,1.0))
+    lines(discretize(path))
+
+    path = BezierPath(Point2f0(0.0,0.0),
+                      Point2f0(0.0,1.0),
+                      Point2f0(0.0,0.0))
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ using Makie.Colors
 # using GLMakie
 using Test
 
+include("beziercurves_test.jl")
+
 @testset "GraphMakie.jl" begin
     g = Node(wheel_digraph(10))
     f, ax, p = graphplot(g)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,9 +34,9 @@ end
 
 @testset "graph without edges" begin
     g = SimpleDiGraph(10)
-    @test_broken graphplot(g)
+    graphplot(g)
     g = SimpleGraph(10)
-    @test_broken graphplot(g)
+    graphplot(g)
 end
 
 @testset "selfedge without neighbors" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,17 +107,17 @@ end
     using GraphMakie: align_to_dir
     using LinearAlgebra: normalize
 
-    @test align_to_dir((:left, :center)) == Point(1.0, 0)
-    @test align_to_dir((:right, :center)) == Point(-1.0, 0)
-    @test align_to_dir((:center, :center)) == Point(0.0, 0)
+    @test align_to_dir((:left, :center)) ≈ Point(1.0, 0)
+    @test align_to_dir((:right, :center)) ≈ Point(-1.0, 0)
+    @test align_to_dir((:center, :center)) ≈ Point(0.0, 0)
 
-    @test align_to_dir((:left, :top)) == normalize(Point(1.0, -1.0))
-    @test align_to_dir((:right, :top)) == normalize(Point(-1.0, -1))
-    @test align_to_dir((:center, :top)) == normalize(Point(0.0, -1))
+    @test align_to_dir((:left, :top)) ≈ normalize(Point(1.0, -1.0))
+    @test align_to_dir((:right, :top)) ≈ normalize(Point(-1.0, -1))
+    @test align_to_dir((:center, :top)) ≈ normalize(Point(0.0, -1))
 
-    @test align_to_dir((:left, :bottom)) == normalize(Point(1.0, 1.0))
-    @test align_to_dir((:right, :bottom)) == normalize(Point(-1.0, 1.0))
-    @test align_to_dir((:center, :bottom)) == normalize(Point(0.0, 1.0))
+    @test align_to_dir((:left, :bottom)) ≈ normalize(Point(1.0, 1.0))
+    @test align_to_dir((:right, :bottom)) ≈ normalize(Point(-1.0, 1.0))
+    @test align_to_dir((:center, :bottom)) ≈ normalize(Point(0.0, 1.0))
 
     # g = complete_graph(9)
     # nlabels_align = vec(collect(Iterators.product((:left,:center,:right),(:top,:center,:bottom))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,8 +70,8 @@ end
     register_interaction!(ax, :eclick, eclick)
 
     function node_drag_action(state, idx, event, axis)
-        p[:node_positions][][idx] = event.data
-        p[:node_positions][] = p[:node_positions][]
+        p[:node_pos][][idx] = event.data
+        p[:node_pos][] = p[:node_pos][]
     end
     ndrag = NodeDragHandler(node_drag_action)
     register_interaction!(ax, :ndrag, ndrag)
@@ -87,13 +87,13 @@ end
         if state == true
             if action.src===action.dst===action.init===nothing
                 action.init = event.data
-                action.src = p[:node_positions][][edge.src]
-                action.dst = p[:node_positions][][edge.dst]
+                action.src = p[:node_pos][][edge.src]
+                action.dst = p[:node_pos][][edge.dst]
             end
             offset = event.data - action.init
-            p[:node_positions][][edge.src] = action.src + offset
-            p[:node_positions][][edge.dst] = action.dst + offset
-            p[:node_positions][] = p[:node_positions][] # trigger change
+            p[:node_pos][][edge.src] = action.src + offset
+            p[:node_pos][][edge.dst] = action.dst + offset
+            p[:node_pos][] = p[:node_pos][] # trigger change
         elseif state == false
             action.src = action.dst = action.init =  nothing
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,8 +32,15 @@ include("beziercurves_test.jl")
     f, ax, p = graphplot(g, node_color=[rand([:blue,:red,:green]) for i in 1:nv(g[])])
 end
 
-@testset "self loop" begin
+@testset "graph without edges" begin
     g = SimpleDiGraph(10)
+    @test_broken graphplot(g)
+    g = SimpleGraph(10)
+    @test_broken graphplot(g)
+end
+
+@testset "selfedge without neighbors" begin
+    g = SimpleGraph(10)
     add_edge!(g, 1, 1)
     graphplot(g)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,7 +130,7 @@ end
     nlabels = repr.(1:nv(g))
     elabels = repr.(1:ne(g))
     fig, ax, p = graphplot(g)
-    @test get_edge_plot(p) isa BezierSegments
+    @test get_edge_plot(p) isa EdgePlot
     @test get_node_plot(p)[1][] == p[:node_pos][]
     @test get_arrow_plot(p).visible[] == false
     @test get_nlabel_plot(p) === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ end
 
 @testset "Hover, click and drag Interaction" begin
     g = wheel_graph(10)
+    add_edge!(g, 1, 1)
     f, ax, p = graphplot(g,
                          edge_width = [3.0 for i in 1:ne(g)],
                          edge_color = [colorant"black" for i in 1:ne(g)],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,3 +148,25 @@ end
     @test get_nlabel_plot(p)[1][] == nlabels
     @test get_elabel_plot(p)[1][] == elabels
 end
+
+@testset "test Pointf0" begin
+    using GraphMakie: Pointf0
+
+    p = Point(0.0, 0.0)
+    @test typeof(Pointf0(p)) == Point2f0
+    @test Pointf0(p) == Point2f0(p)
+
+    p = Point(1, 0)
+    @test typeof(Pointf0(p)) == Point2f0
+    @test Pointf0(p) == Point2f0(p)
+
+    p = Point(0.0, 1.0, 2.0)
+    @test typeof(Pointf0(p)) == Point3f0
+    @test Pointf0(p) == Point3f0(p)
+
+    @test Pointf0(0.0, 0.0, 0.0) isa Point3f0
+    @test Pointf0(1.0, 1.0) isa Point2f0
+
+    @test Pointf0((0.0, 0.0, 0.0 )) isa Point3f0
+    @test Pointf0((1.0, 1.0)) isa  Point2f0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,3 +124,26 @@ end
     # graphplot(g; nlabels, nlabels_align, nlabels_distance=20)
 end
 
+@testset "test plot accessors" begin
+    g = complete_graph(10)
+    nlabels = repr.(1:nv(g))
+    elabels = repr.(1:ne(g))
+    fig, ax, p = graphplot(g)
+    @test get_edge_plot(p) isa BezierSegments
+    @test get_node_plot(p)[1][] == p[:node_pos][]
+    @test get_arrow_plot(p).visible[] == false
+    @test get_nlabel_plot(p) === nothing
+    @test get_elabel_plot(p) === nothing
+
+    fig, ax, p = graphplot(g; nlabels)
+    @test get_nlabel_plot(p)[1][] == nlabels
+    @test get_elabel_plot(p) === nothing
+
+    fig, ax, p = graphplot(g; elabels)
+    @test get_nlabel_plot(p) === nothing
+    @test get_elabel_plot(p)[1][] == elabels
+
+    fig, ax, p = graphplot(g; elabels, nlabels)
+    @test get_nlabel_plot(p)[1][] == nlabels
+    @test get_elabel_plot(p)[1][] == elabels
+end


### PR DESCRIPTION
I've started implementing curvy lines to adress #23.
Before this PR all edges have been drawn as `linesegments`. Now each edge is represented by a bezier path. This allows for fancy graphs like this

<img width="400" alt="grafik" src="https://user-images.githubusercontent.com/35867212/126477074-6747c876-8495-4361-b252-b9f41be63a19.png">

and will also enable self loops.

- [x] added bezierpaths recipe
- [x] get positions and angles in px space along curves (to place edge labels and arrow heads correctly)
- [x] use loops for self edges (how to determine the direction of the loop?)
- [x] add usefull attributes to enable curvy lines (the tree example above was hard coded in the recipe ^^)
- [x] update the whole interaction business for the new edge plot type

unfortunately since each path is drawn as a `line` we lost the option to have pointy edges with different linewidth at each end. But this wasn't supported on CairoMakie anyway...
@SimonDanisch would it be possible to add such feature to `lines` in makie? I.e. allow for 2 linewidths per line, one for the start and one for the end?