### PR TITLE
add `curve_distance` attribute

### DIFF
--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -177,7 +177,19 @@ f # hide
 #=
 ## Curvy edges
 
-Curvy edges are possible using the low level interface of passing tangent
+The easiest way to enable curvy edges is to use the `curve_distance` parameter which lets
+you add a "distance" parameter (for all edges or on a per edge basis as array or dict).
+The parameter changes the maximum distance of the bent line to a straight line.
+=#
+g = complete_digraph(3)
+distances = collect(0.05:0.05:ne(g)*0.05)
+elabels = "d = ".* repr.(round.(distances, digits=2))
+f, ax, p = graphplot(g; curve_distance=distances, elabels, arrow_size=20)
+hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
+f # hide
+
+#=
+Curvy edges are also possible using the low level interface of passing tangent
 vectors and a `tfactor`. The tangent vectors can be `nothing` (straight line) or
 two vectors per edge (one for src vertex, one for dst vertex). The `tfactor`
 scales the distance of the bezier control point relative to the distance of src

--- a/docs/examples/plots.jl
+++ b/docs/examples/plots.jl
@@ -176,10 +176,31 @@ f # hide
 
 #=
 ## Curvy edges
+### `curve_distance` interface
 
-The easiest way to enable curvy edges is to use the `curve_distance` parameter which lets
-you add a "distance" parameter (for all edges or on a per edge basis as array or dict).
-The parameter changes the maximum distance of the bent line to a straight line.
+The easiest way to enable curvy edges is to use the `curve_distance` parameter
+which lets you add a "distance" parameter. The parameter changes the maximum
+distance of the bent line to a straight line. Per default, only two way edges will
+be drawn as a curve:
+=#
+g = SimpleDiGraph(3); add_edge!(g, 1, 2); add_edge!(g, 2, 3); add_edge!(g, 3, 1); add_edge!(g, 1, 3)
+
+f, ax, p = graphplot(g)
+hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
+f #hide
+
+#=
+This behaviour may be changed by using the `curve_distance_usage=Makie.automatic` parameter.
+ - `Makie.automatic`: Only apply `curve_distance` to double edges.
+ - `true`: Use on all edges.
+ - `false`: Don't use.
+=#
+f, ax, p = graphplot(g; curve_distance=-.5, curve_distance_usage=true)
+hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
+f #hide
+
+#=
+It is also possible to specify the distance on a per edge base:
 =#
 g = complete_digraph(3)
 distances = collect(0.05:0.05:ne(g)*0.05)
@@ -189,6 +210,8 @@ hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect()
 f # hide
 
 #=
+### `tangents` interface
+
 Curvy edges are also possible using the low level interface of passing tangent
 vectors and a `tfactor`. The tangent vectors can be `nothing` (straight line) or
 two vectors per edge (one for src vertex, one for dst vertex). The `tfactor`

--- a/src/beziercurves.jl
+++ b/src/beziercurves.jl
@@ -173,7 +173,7 @@ isline(p::BezierPath) = length(p.commands)==2 && p.commands[1] isa MoveTo && p.c
 Create a bezier path by natural cubic spline interpolation of the points `P`.
 If there are only two points and no tangents return a straight line.
 
-The `tangets` kw allows you pass two vectors as tangents for the first and the
+The `tangents` kw allows you pass two vectors as tangents for the first and the
 last point. The `tfactor` affects the curvature on the start and end given some
 tangents.
 """

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -75,6 +75,11 @@ the edge.
 - `selfedge_size=Makie.automatic()`: Size of self-edge-loop (dict/vector possible).
 - `selfedge_direction=Makie.automatic()`: Direction of self-edge-loop as `Point2` (dict/vector possible).
 - `selfedge_width=Makie.automatic()`: Opening of selfloop in rad (dict/vector possible).
+- `curve_distance=0.0`:
+
+    Specify a distance of the (now curved) line to the straight line. Can be single value, array or Dict.
+    User proivded `tangents` or `waypoints` will overrule this property.
+
 - `tangents=nothing`:
 
     Specify a pair of tangent vectors per edge (for src and dst). If `nothing`
@@ -139,6 +144,7 @@ the edge.
         selfedge_size = automatic,
         selfedge_direction = automatic,
         selfedge_width = automatic,
+        curve_distance = 0.0,
         tangents=nothing,
         tfactor=0.6,
         waypoints=nothing,
@@ -309,19 +315,19 @@ function find_edge_paths(g, attr, pos::AbstractVector{PT}) where {PT}
     ne(g) == 0 && return paths
 
     for (i, e) in enumerate(edges(g))
-        if e.src == e.dst
+        if e.src == e.dst # selfedge
             size = getattr(attr.selfedge_size, i)
             direction = getattr(attr.selfedge_direction, i)
             width = getattr(attr.selfedge_width, i)
             paths[i] = selfedge_path(g, pos, e.src, size, direction, width)
-        else
+        else # no selfedge
             p1, p2 = pos[e.src], pos[e.dst]
             tangents = getattr(attr.tangents, i)
             tfactor = getattr(attr.tfactor, i)
             waypoints::Vector{PT} = getattr(attr.waypoints, i, PT[])
-            if isnothing(waypoints) || isempty(waypoints)
-                paths[i] = Path(p1, p2; tangents, tfactor)
-            else
+            curve_distance = getattr(attr.curve_distance, i, 0.0)
+
+            if !isnothing(waypoints) && !isempty(waypoints) #there are waypoints
                 # the waypoints may already include the endpoints
                 waypoints[begin] == p1 && popfirst!(waypoints)
                 waypoints[end] == p2 && pop!(waypoints)
@@ -335,6 +341,22 @@ function find_edge_paths(g, attr, pos::AbstractVector{PT}) where {PT}
                 else
                     throw(ArgumentError("Invalid radius $radius for edge $i!"))
                 end
+            elseif !isnothing(tangents)
+                paths[i] = Path(p1, p2; tangents, tfactor)
+            elseif PT<:Point2 && !iszero(curve_distance)
+                d = curve_distance
+                s = norm(p2 - p1)
+                γ = 2*atan(2 * d/s)
+                a = (p2 - p1)/s * (4*d^2 + s^2)/(3s)
+
+                m = @SMatrix[cos(γ) -sin(γ); sin(γ) cos(γ)]
+                c1 = PT(p1 + m*a)
+                c2 = PT(p2 - transpose(m)*a)
+
+                commands = [MoveTo(p1), CurveTo(c1, c2, p2)]
+                paths[i] = BezierPath(commands)
+            else # straight line
+                paths[i] = Path(p1, p2)
             end
         end
     end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -69,16 +69,30 @@ the edge.
 - `elabels_textsize=labels_theme.textsize`
 - `elabels_attr=(;)`: List of kw arguments which gets passed to the `text` command
 
-### self edges & curvy edges
+### Curvy edges & self edges/loops
 - `edge_plottype=Makie.automatic()`: Either `automatic`, `:linesegments` or
   `:beziersegments`. `:beziersegments` are much slower for big graphs!
+
+Self edges / loops:
+
 - `selfedge_size=Makie.automatic()`: Size of self-edge-loop (dict/vector possible).
 - `selfedge_direction=Makie.automatic()`: Direction of self-edge-loop as `Point2` (dict/vector possible).
 - `selfedge_width=Makie.automatic()`: Opening of selfloop in rad (dict/vector possible).
-- `curve_distance=0.0`:
 
-    Specify a distance of the (now curved) line to the straight line. Can be single value, array or Dict.
-    User proivded `tangents` or `waypoints` will overrule this property.
+High level interface for curvy edges:
+
+- `curve_distance=0.1`:
+
+    Specify a distance of the (now curved) line to the straight line *in data
+    space*. Can be single value, array or dict. User proivded `tangents` or
+    `waypoints` will overrule this property.
+
+- `curve_distance_usage=Makie.automatic()`:
+
+    If `Makie.automatic()`, only plot double edges in a curvy way. Other options
+    are `true` and `false`.
+
+Tangents interface for curvy edges:
 
 - `tangents=nothing`:
 
@@ -91,6 +105,7 @@ the edge.
     Higher factor means bigger radius. Can be tuple per edge to specify different
     factor for src and dst.
 
+Waypoints along edges:
 - `waypoints=nothing`
 
     Specify waypoints for edges. This parameter should be given as a vector or
@@ -144,7 +159,8 @@ the edge.
         selfedge_size = automatic,
         selfedge_direction = automatic,
         selfedge_width = automatic,
-        curve_distance = 0.0,
+        curve_distance = 0.1,
+        curve_distance_usage = automatic,
         tangents=nothing,
         tfactor=0.6,
         waypoints=nothing,
@@ -325,7 +341,20 @@ function find_edge_paths(g, attr, pos::AbstractVector{PT}) where {PT}
             tangents = getattr(attr.tangents, i)
             tfactor = getattr(attr.tfactor, i)
             waypoints::Vector{PT} = getattr(attr.waypoints, i, PT[])
-            curve_distance = getattr(attr.curve_distance, i, 0.0)
+
+            cdu = getattr(attr.curve_distance_usage, i)
+            if cdu === true
+                curve_distance = getattr(attr.curve_distance, i, 0.0)
+            elseif cdu === false
+                curve_distance = 0.0
+            elseif cdu === automatic
+                if is_directed(g) && has_edge(g, e.dst, e.src)
+                    println("directed and has ege")
+                    curve_distance = getattr(attr.curve_distance, i, 0.0)
+                else
+                    curve_distance = 0.0
+                end
+            end
 
             if !isnothing(waypoints) && !isempty(waypoints) #there are waypoints
                 # the waypoints may already include the endpoints

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -4,7 +4,7 @@ using GeometryBasics
 
 using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, tangent, waypoints, Path, Line
 
-@testset "interpolation and tangets" begin
+@testset "interpolation and tangents" begin
     path = BezierPath([
         MoveTo(Point2f(0,0)),
         LineTo(Point2f(0.5,0.5)),
@@ -71,7 +71,7 @@ end
     scatter!(waypoints(path))
 end
 
-@testset "two points and tangets" begin
+@testset "two points and tangents" begin
     p1 = Point2f(0,0)
     t1 = Point2f(0,1)
     p2 = Point2f(1,1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,3 +199,21 @@ end
     @test Pointf((0.0, 0.0, 0.0 )) isa Point3f
     @test Pointf((1.0, 1.0)) isa  Point2f
 end
+
+@testset "test edges distance parameters" begin
+    g = SimpleDiGraph(3)
+    add_edge!(g, 1, 2)
+    add_edge!(g, 2, 3)
+    add_edge!(g, 3, 1)
+
+    graphplot(g)
+
+    add_edge!(g, 1, 3)
+
+    graphplot(g; curve_distance=0.2)
+    graphplot(g; curve_distance=0.2, curve_distance_usage=false)
+    graphplot(g; curve_distance=0.2, curve_distance_usage=true)
+
+    graphplot(g; curve_distance=collect(0.1:0.1:0.5))
+    graphplot(g; curve_distance=collect(0.1:0.1:0.5), curve_distance_usage=true)
+end


### PR DESCRIPTION
This is a proposed solution for #37 
It adds a `curve_distance` attribute which may be set for each edge individual. This is meant at an easy interface to enable curvy edges (especially for directed graphs).

- [x] docs
- [ ] what about pixel space vs data space?

https://user-images.githubusercontent.com/35867212/149530956-8021854a-a60b-4dba-808a-567ac5925226.mov

```julia
g = complete_digraph(3)
distances = collect(0.05:0.05:ne(g)*0.05)
elabels = "d = ".* repr.(round.(distances, digits=2))
fig, ax, p = graphplot(g; curve_distance=distances, elabels)

deregister_interaction!(ax, :rectanglezoom)
function node_drag_action(state, idx, event, axis)
    p[:node_pos][][idx] = event.data
    p[:node_pos][] = p[:node_pos][]
end
ndrag = NodeDragHandler(node_drag_action)
register_interaction!(ax, :ndrag, ndrag)
```
