### PR TITLE
bump Makie version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 GeometryBasics = "0.4"
 Graphs = "1.4"
-Makie = "0.15"
+Makie = "0.15, 0.16"
 NetworkLayout = "0.4.3"
 StaticArrays = "1.2"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 GeometryBasics = "0.4"
 Graphs = "1.4"
-Makie = "0.15, 0.16"
+Makie = "0.15, 0.16.4"
 NetworkLayout = "0.4.3"
 StaticArrays = "1.2"
 julia = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Test
 include("beziercurves_test.jl")
 
 @testset "GraphMakie.jl" begin
-    g = Node(wheel_digraph(10))
+    g = Observable(wheel_digraph(10))
     f, ax, p = graphplot(g)
     f, ax, p = graphplot(g, node_attr=Attributes(visible=false))
     f, ax, p = graphplot(g, node_attr=(;visible=true))


### PR DESCRIPTION
Requires a tag in Makie (and updating the compat bound to 0.16.4 here) to pass tests.