### PR TITLE
separate edge paths from drawn paths

### DIFF
--- a/src/beziercurves.jl
+++ b/src/beziercurves.jl
@@ -39,6 +39,8 @@ end
 
 ptype(::Union{AbstractPath{PT}, Type{<:AbstractPath{PT}}}) where {PT} = PT
 
+straighten(l::Line) = l
+straighten(p::BezierPath) = Line(interpolate(p,0.0), interpolate(p,1.0))
 
 ####
 #### Helper functions to work with bezier pathes

--- a/test/beziercurves_test.jl
+++ b/test/beziercurves_test.jl
@@ -2,7 +2,7 @@ using Test
 using GraphMakie
 using GeometryBasics
 
-using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, tangent, waypoints, Path, Line
+using GraphMakie: BezierPath, MoveTo, LineTo, CurveTo, interpolate, discretize, tangent, waypoints, Path, Line, straighten
 
 @testset "interpolation and tangents" begin
     path = BezierPath([
@@ -144,4 +144,17 @@ end
     g = star_graph(10)
     add_edge!(g, 1, 1)
     @test_throws ErrorException graphplot(g; layout=_->rand(Point3f, 10))
+end
+
+@testset "conversion to line" begin
+    path = BezierPath([
+        MoveTo(Point2f(0,0)),
+        LineTo(Point2f(0.5,0.5)),
+        CurveTo(Point2f(1,0),
+                Point2f(1,0),
+                Point2f(1,1)),
+        CurveTo(Point2f(1,2),
+                Point2f(0,2),
+                Point2f(0,1))])
+    @test straighten(path) == Line(Point2f(0,0), Point2f(0,1))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,3 +241,15 @@ end
     graphplot(g; curve_distance=collect(0.1:0.1:0.5))
     graphplot(g; curve_distance=collect(0.1:0.1:0.5), curve_distance_usage=true)
 end
+
+@testset "attribute copys" begin
+    orig = Attributes(:foo => 1, :bar=>"2", :baz=>3.0)
+    cp = copy(orig)
+    delete!(cp, :foo)
+
+    @test orig.bar[] == cp.bar[]
+    @test orig.baz[] == cp.baz[]
+    orig.bar[] = "change"
+    @test orig.bar[] == cp.bar[] == "change"
+    @test orig.baz[] == cp.baz[] == 3.0
+end


### PR DESCRIPTION
fixes #64 , label and arrow head positioned along the edge pathes. This does not work if the actuall pathes are converted to straight lines on the edgeplot level.