### PR TITLE
Invisible vertices

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -125,6 +125,7 @@ Waypoints along edges:
         node_color = scatter_theme.color,
         node_size = scatter_theme.markersize,
         node_marker = scatter_theme.marker,
+        node_invis = nothing,
         node_attr = (;),
         # edge attributes (LineSegements)
         edge_color = lineseg_theme.color,
@@ -224,13 +225,20 @@ function Makie.plot!(gp::GraphPlot)
                            visible = arrow_show,
                            gp.arrow_attr...)
 
-    # plot vertices
-    vertex_plot = scatter!(gp, node_pos;
-                           color=gp.node_color,
-                           marker=gp.node_marker,
-                           markersize=gp.node_size,
-                           gp.node_attr...)
 
+    node_pos_invis = @lift filter_out($node_pos, $(gp.node_invis))
+    node_color_invis= @lift filter_out($(gp.node_color), $(gp.node_invis))
+    node_marker_invis = @lift filter_out($(gp.node_marker), $(gp.node_invis))
+    node_size_invis = @lift filter_out($(gp.node_size), $(gp.node_invis))
+    vertex_plot = scatter!(gp, node_pos_invis;
+                           color=node_color_invis,
+                           marker=node_marker_invis,
+                           markersize=node_size_invis,
+                           filter_out(gp.node_attr, gp.node_invis[])...)
+
+    if gp.node_invis[] != nothing
+        gp.nlabels[][gp.node_invis[]] .= ""
+    end
     # plot node labels
     if gp.nlabels[] !== nothing
         positions = @lift begin

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -121,3 +121,12 @@ function plot_controlpoints!(ax::Axis, p::BezierPath; color=:black)
         end
     end
 end
+
+"""
+    filter_out(v::Vector, idxs)
+Filter out indices in `idxs` in vector `v`
+"""
+filter_out(v::AbstractVector, idxs) = return idxs === nothing ? v : v[1:end .∉ [idxs]]
+filter_out(v, idxs) = return v
+filter_out(nt::NamedTuple, idxs) =  (;zip(keys(nt), GraphMakie.filter_out.(values(nt),[idxs]))...)
+filter_out(ats::Attributes, idxs) =  Attributes(;zip(keys(ats), GraphMakie.filter_out.(getindex.(values(ats),),[idxs]))...)


### PR DESCRIPTION
# General
Introduces `node_invis` attribute.
Node indices passed in `node_invis` will not be drawn.
Node labels will also not be drawn
Edges will be drawn normally.

# Motivation
I've been needing to have this feature for a personal project, to which I need to draw edges without drawing all nodes.
In essence this PR works towards having floating edges.
Another use case could be to have composite edges, which can be drawn as a series of simple edges connected by invisible nodes.

# Example
```julia
gc = circular_ladder_graph(5)
f,a,p = graphplot(gc, node_invis=[2,3,7], nlabels=repr.(vertices(gc)), node_color=:blue, node_attr=(markersize = LinRange(11, 20, 10),))
```
![image](https://user-images.githubusercontent.com/27723218/161449170-85c98080-e138-4131-b710-3367d9276b48.png)


# Inner Workings
Defines function `filter_out`.
Scatter is using `filter_out` for all arguments passed in.
Node Labels are just reevaluated by doing `gp.nlabels[][gp.node_invis[]] .= ""`

Feel free to mention if this would not be an appropriate feature or if you have problems with the implementation.
I directly did the PR because the code was available already from my side and probably it's easier for discussion.