### PR TITLE
Fix for mixed scalar/vector elabels properties

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -329,7 +329,7 @@ function elabels_distance_offset(g, attrs)
                 offs[i] = zero(attrval)
             end
         elseif attrval == automatic
-            offval = (attrs.elabels_textsize[] + attrs.edge_width[])/2
+            offval = (attrs.elabels_textsize[] .+ attrs.edge_width[])/2
             if attrvalside == :left
                 offs[i] = offval
             elseif attrvalside == :right


### PR DESCRIPTION
This fixes a minor bug that occurs when e.g. `elabels_width` is a vector, but `elabels_textsize` is a scalar (in which case, this lines throws a `MethodError: no method matching +(::Int64, ::Vector{Float64})`).