### PR TITLE
Support non-scalar node_size in distance_between_markers

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -216,25 +216,15 @@ TODO: Implement for noncircular marker1.
       (will require angle for line joining the 2 markers).
 
 `size1` / `size2` may be scalars or `(width, height)` / `Vec2` marker sizes;
-non-scalar sizes use the larger axis (circumscribed extent).
+non-scalar sizes use `maximum` (larger axis / circumscribed extent).
 """
 function distance_between_markers(marker1, size1, marker2, size2)
     marker1_scale = scale_factor(marker1)
     marker2_scale = scale_factor(marker2)
-    d = marker1_scale * _marker_size_extent(size1) / 2 +
-        marker2_scale * _marker_size_extent(size2) / 2
+    d = marker1_scale * maximum(size1) / 2 +
+        marker2_scale * maximum(size2) / 2
 
     return d
-end
-
-"""Largest pixel extent of a marker size (scalar or 2-vector / tuple)."""
-_marker_size_extent(size::Real) = Float64(size)
-_marker_size_extent(size::Tuple{<:Real, <:Real}) = Float64(max(size[1], size[2]))
-function _marker_size_extent(size)
-    if applicable(length, size) && length(size) >= 2
-        return Float64(max(size[1], size[2]))
-    end
-    return Float64(size)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -214,13 +214,27 @@ end
 Calculate distance between 2 markers.
 TODO: Implement for noncircular marker1.
       (will require angle for line joining the 2 markers).
+
+`size1` / `size2` may be scalars or `(width, height)` / `Vec2` marker sizes;
+non-scalar sizes use the larger axis (circumscribed extent).
 """
 function distance_between_markers(marker1, size1, marker2, size2)
     marker1_scale = scale_factor(marker1)
     marker2_scale = scale_factor(marker2)
-    d = marker1_scale*size1/2 + marker2_scale*size2/2
+    d = marker1_scale * _marker_size_extent(size1) / 2 +
+        marker2_scale * _marker_size_extent(size2) / 2
 
     return d
+end
+
+"""Largest pixel extent of a marker size (scalar or 2-vector / tuple)."""
+_marker_size_extent(size::Real) = Float64(size)
+_marker_size_extent(size::Tuple{<:Real, <:Real}) = Float64(max(size[1], size[2]))
+function _marker_size_extent(size)
+    if applicable(length, size) && length(size) >= 2
+        return Float64(max(size[1], size[2]))
+    end
+    return Float64(size)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,6 +165,22 @@ end
     # graphplot(g; nlabels, nlabels_align, nlabels_distance=20)
 end
 
+@testset "distance_between_markers" begin
+    using GraphMakie: distance_between_markers, scale_factor
+    using GeometryBasics: Vec2
+
+    d_scalar = distance_between_markers(:circle, 34, '➤', 14)
+    @test d_scalar ≈ scale_factor(:circle) * 34 / 2 + scale_factor('➤') * 14 / 2
+
+    # Rectangular node sizes: use the larger axis (same as maximum)
+    d_tuple = distance_between_markers(:rect, (132, 84), '➤', 14)
+    @test d_tuple ≈ scale_factor(:rect) * 132 / 2 + scale_factor('➤') * 14 / 2
+    @test d_tuple ≈ distance_between_markers(:rect, 132, '➤', 14)
+
+    d_vec = distance_between_markers(:rect, Vec2(105.0, 80.0), '➤', 14)
+    @test d_vec ≈ distance_between_markers(:rect, 105.0, '➤', 14)
+end
+
 @testset "test plot accessors" begin
     g = complete_graph(10)
     nlabels = repr.(1:nv(g))


### PR DESCRIPTION
## Summary

`distance_between_markers` currently does `scale * size / 2`, which errors when `node_size` is a `(width, height)` tuple or `Vec2` (common for rectangular nodes):

```
MethodError: no method matching *(::Float64, ::Tuple{Int64, Int64})
```

This patch introduces `_marker_size_extent`, which uses the larger axis for non-scalar sizes (circumscribed extent), matching how rectangular markers are typically laid out.

## Motivation

Downstream packages such as DAGMakie use rectangular `node_size` for SWIG / panel-style nodes. Against registry GraphMakie 0.6.x those figures fail in AutoMerge CI; scalar-only sizes are a workaround, not a fix.

## Test plan

- [x] Existing GraphMakie CI
- [ ] Manual: `graphplot` with mixed scalar and tuple `node_size` should place edge endpoints without MethodError